### PR TITLE
feat: Normal Checklist

### DIFF
--- a/B78XH/B78XH.vcxproj
+++ b/B78XH/B78XH.vcxproj
@@ -266,6 +266,7 @@
     <ClCompile Include="PFDTargetAltitudeApplication.cpp" />
     <ClCompile Include="PFDVerticalSpeedIndicator.cpp" />
     <ClCompile Include="PFDVerticalSpeedIndicatorApplication.cpp" />
+    <ClCompile Include="PreFlightCheckList.cpp" />
     <ClCompile Include="RadioNav.cpp" />
     <ClCompile Include="RedApplication.cpp" />
     <ClCompile Include="RightInboardDisplay.cpp" />
@@ -488,6 +489,7 @@
     <ClInclude Include="PFDTargetAirspeedApplication.h" />
     <ClInclude Include="PFDTargetAltitudeApplication.h" />
     <ClInclude Include="PFDVerticalSpeedIndicatorApplication.h" />
+    <ClInclude Include="PreFlightCheckList.h" />
     <ClInclude Include="RadioNav.h" />
     <ClInclude Include="RedApplication.h" />
     <ClInclude Include="RightInboardDisplay.h" />

--- a/B78XH/B78XH.vcxproj
+++ b/B78XH/B78XH.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="CDURoutePageControl.cpp" />
     <ClCompile Include="CDUScratchpadControl.cpp" />
     <ClCompile Include="CDUSelectKeyButtonControl.cpp" />
+    <ClCompile Include="CheckList.cpp" />
     <ClCompile Include="CheckListButton.cpp" />
     <ClCompile Include="CheckListItem.cpp" />
     <ClCompile Include="CheckListLine.cpp" />
@@ -378,6 +379,7 @@
     <ClInclude Include="CDURoutePageControl.h" />
     <ClInclude Include="CDUScratchpadControl.h" />
     <ClInclude Include="CDUSelectKeyButtonControl.h" />
+    <ClInclude Include="CheckList.h" />
     <ClInclude Include="CheckListButton.h" />
     <ClInclude Include="CheckListDimensions.h" />
     <ClInclude Include="CheckListItem.h" />

--- a/B78XH/B78XH.vcxproj
+++ b/B78XH/B78XH.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="CheckListLine.cpp" />
     <ClCompile Include="CheckListLineSingle.cpp" />
     <ClCompile Include="CheckListLineStateIndicator.cpp" />
+    <ClCompile Include="CheckListStatus.cpp" />
     <ClCompile Include="CheckListTitle.cpp" />
     <ClCompile Include="MFDCHKLControl.cpp" />
     <ClCompile Include="MFDMouseCursorControl.cpp" />
@@ -387,6 +388,7 @@
     <ClInclude Include="CheckListLine.h" />
     <ClInclude Include="CheckListLineSingle.h" />
     <ClInclude Include="CheckListLineStateIndicator.h" />
+    <ClInclude Include="CheckListStatus.h" />
     <ClInclude Include="CheckListTitle.h" />
     <ClInclude Include="MFDCHKLControl.h" />
     <ClInclude Include="MFDMouseCursorControl.h" />

--- a/B78XH/B78XH.vcxproj
+++ b/B78XH/B78XH.vcxproj
@@ -156,7 +156,9 @@
     <ClCompile Include="CheckListButton.cpp" />
     <ClCompile Include="CheckListItem.cpp" />
     <ClCompile Include="CheckListLine.cpp" />
+    <ClCompile Include="CheckListLineSingle.cpp" />
     <ClCompile Include="CheckListLineStateIndicator.cpp" />
+    <ClCompile Include="CheckListTitle.cpp" />
     <ClCompile Include="MFDCHKLControl.cpp" />
     <ClCompile Include="MFDMouseCursorControl.cpp" />
     <ClCompile Include="CDUMouseMoveResolver.cpp" />
@@ -380,7 +382,9 @@
     <ClInclude Include="CheckListDimensions.h" />
     <ClInclude Include="CheckListItem.h" />
     <ClInclude Include="CheckListLine.h" />
+    <ClInclude Include="CheckListLineSingle.h" />
     <ClInclude Include="CheckListLineStateIndicator.h" />
+    <ClInclude Include="CheckListTitle.h" />
     <ClInclude Include="MFDCHKLControl.h" />
     <ClInclude Include="MFDMouseCursorControl.h" />
     <ClInclude Include="CDUMouseMoveResolver.h" />

--- a/B78XH/B78XH.vcxproj
+++ b/B78XH/B78XH.vcxproj
@@ -51,7 +51,7 @@
     <LinkIncremental>true</LinkIncremental>
     <TargetExt>.wasm</TargetExt>
     <IncludePath>$(MSFS_IncludePath);$(CPP_EXTERNALS)\include\NANOVG;</IncludePath>
-    <OutDir>..\..\..\..\WebstormProjects\B78XH-INTERIOR\SimObjects\Airplanes\Asobo_B787_10\panel</OutDir>
+    <OutDir>..\..\B78XH\SimObjects\Airplanes\Heavy-Division-B78XH-mod\panel</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|MSFS'">
     <LinkIncremental>false</LinkIncremental>
@@ -153,6 +153,10 @@
     <ClCompile Include="CDURoutePageControl.cpp" />
     <ClCompile Include="CDUScratchpadControl.cpp" />
     <ClCompile Include="CDUSelectKeyButtonControl.cpp" />
+    <ClCompile Include="CheckListItem.cpp" />
+    <ClCompile Include="CheckListLine.cpp" />
+    <ClCompile Include="CheckListLineStateIndicator.cpp" />
+    <ClCompile Include="MFDCHKLControl.cpp" />
     <ClCompile Include="MFDMouseCursorControl.cpp" />
     <ClCompile Include="CDUMouseMoveResolver.cpp" />
     <ClCompile Include="CDUMouseResolver.cpp" />
@@ -371,6 +375,11 @@
     <ClInclude Include="CDURoutePageControl.h" />
     <ClInclude Include="CDUScratchpadControl.h" />
     <ClInclude Include="CDUSelectKeyButtonControl.h" />
+    <ClInclude Include="CheckListDimensions.h" />
+    <ClInclude Include="CheckListItem.h" />
+    <ClInclude Include="CheckListLine.h" />
+    <ClInclude Include="CheckListLineStateIndicator.h" />
+    <ClInclude Include="MFDCHKLControl.h" />
     <ClInclude Include="MFDMouseCursorControl.h" />
     <ClInclude Include="CDUMouseMoveResolver.h" />
     <ClInclude Include="CDUMouseResolver.h" />

--- a/B78XH/B78XH.vcxproj
+++ b/B78XH/B78XH.vcxproj
@@ -153,6 +153,7 @@
     <ClCompile Include="CDURoutePageControl.cpp" />
     <ClCompile Include="CDUScratchpadControl.cpp" />
     <ClCompile Include="CDUSelectKeyButtonControl.cpp" />
+    <ClCompile Include="CheckListButton.cpp" />
     <ClCompile Include="CheckListItem.cpp" />
     <ClCompile Include="CheckListLine.cpp" />
     <ClCompile Include="CheckListLineStateIndicator.cpp" />
@@ -375,6 +376,7 @@
     <ClInclude Include="CDURoutePageControl.h" />
     <ClInclude Include="CDUScratchpadControl.h" />
     <ClInclude Include="CDUSelectKeyButtonControl.h" />
+    <ClInclude Include="CheckListButton.h" />
     <ClInclude Include="CheckListDimensions.h" />
     <ClInclude Include="CheckListItem.h" />
     <ClInclude Include="CheckListLine.h" />

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -616,13 +616,13 @@
     <ClCompile Include="MFDCHKLControl.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList</Filter>
     </ClCompile>
-    <ClCompile Include="CheckListItem.cpp">
-      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
-    </ClCompile>
     <ClCompile Include="CheckListLineStateIndicator.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClCompile>
     <ClCompile Include="CheckListLine.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
+    <ClCompile Include="CheckListItem.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClCompile>
   </ItemGroup>

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -640,6 +640,9 @@
     <ClCompile Include="PreFlightCheckList.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckLists</Filter>
     </ClCompile>
+    <ClCompile Include="CheckListStatus.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MCPAltitudeGauge.h">
@@ -1388,6 +1391,9 @@
     </ClInclude>
     <ClInclude Include="PreFlightCheckList.h">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckLists</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListStatus.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -625,6 +625,9 @@
     <ClCompile Include="CheckListItem.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClCompile>
+    <ClCompile Include="CheckListButton.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MCPAltitudeGauge.h">
@@ -1357,6 +1360,9 @@
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
     <ClInclude Include="CheckListDimensions.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListButton.h">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
   </ItemGroup>

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -634,6 +634,9 @@
     <ClCompile Include="CheckListLineSingle.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClCompile>
+    <ClCompile Include="CheckList.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MCPAltitudeGauge.h">
@@ -1375,6 +1378,9 @@
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
     <ClInclude Include="CheckListLineSingle.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckList.h">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
   </ItemGroup>

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -637,6 +637,9 @@
     <ClCompile Include="CheckList.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClCompile>
+    <ClCompile Include="PreFlightCheckList.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckLists</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MCPAltitudeGauge.h">
@@ -1383,6 +1386,9 @@
     <ClInclude Include="CheckList.h">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
+    <ClInclude Include="PreFlightCheckList.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckLists</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">
@@ -1708,6 +1714,9 @@
     </Filter>
     <Filter Include="Source Files\Controls\Controls\MFD\CheckList\CheckListBasics">
       <UniqueIdentifier>{1b4f3874-894c-4757-b210-c6ef873b9b07}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Controls\Controls\MFD\CheckList\CheckLists">
+      <UniqueIdentifier>{39e6dbd1-ca13-4115-a6a3-f07a70a71a11}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -613,6 +613,18 @@
     <ClCompile Include="MFDNDControl.cpp">
       <Filter>Source Files\Controls\Controls\MFD\ND</Filter>
     </ClCompile>
+    <ClCompile Include="MFDCHKLControl.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList</Filter>
+    </ClCompile>
+    <ClCompile Include="CheckListItem.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
+    <ClCompile Include="CheckListLineStateIndicator.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
+    <ClCompile Include="CheckListLine.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MCPAltitudeGauge.h">
@@ -1332,6 +1344,21 @@
     <ClInclude Include="MFDNDControl.h">
       <Filter>Source Files\Controls\Controls\MFD\ND</Filter>
     </ClInclude>
+    <ClInclude Include="MFDCHKLControl.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListItem.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListLineStateIndicator.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListLine.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListDimensions.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Header Files">
@@ -1651,6 +1678,12 @@
     </Filter>
     <Filter Include="Source Files\Controls\Controls\MFD\ND">
       <UniqueIdentifier>{983f63d5-9b41-4db6-a45a-80ca39311e9c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Controls\Controls\MFD\CheckList">
+      <UniqueIdentifier>{41a37572-c463-484a-bf96-160e9f8155a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Controls\Controls\MFD\CheckList\CheckListBasics">
+      <UniqueIdentifier>{1b4f3874-894c-4757-b210-c6ef873b9b07}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/B78XH/B78XH.vcxproj.filters
+++ b/B78XH/B78XH.vcxproj.filters
@@ -628,6 +628,12 @@
     <ClCompile Include="CheckListButton.cpp">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClCompile>
+    <ClCompile Include="CheckListTitle.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
+    <ClCompile Include="CheckListLineSingle.cpp">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MCPAltitudeGauge.h">
@@ -1363,6 +1369,12 @@
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
     <ClInclude Include="CheckListButton.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListTitle.h">
+      <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
+    </ClInclude>
+    <ClInclude Include="CheckListLineSingle.h">
       <Filter>Source Files\Controls\Controls\MFD\CheckList\CheckListBasics</Filter>
     </ClInclude>
   </ItemGroup>

--- a/B78XH/CheckList.cpp
+++ b/B78XH/CheckList.cpp
@@ -1,0 +1,56 @@
+#include "CheckList.h"
+
+void CheckList::setupControls() {
+    CheckListItem::setupControls();
+    addOnBeforeRender([this](BaseControl&) -> bool {
+        serviceChecklistUpdateLoop();
+        return true;
+    });
+}
+
+auto CheckList::checkChecklistCompleted() -> void {
+    if (getCurrentState() == CHECKLIST_ITEM_STATE::OVERRIDDEN) {
+        return; // overridden checklist must be explicitly cleared
+    }
+    for (const std::shared_ptr<CheckListLine> l : lines_) {
+        if (l->getCurrentState() == CHECKLIST_ITEM_STATE::OPEN) {
+            setCurrentState(CHECKLIST_ITEM_STATE::OPEN);
+            break;
+        }
+    }
+}
+
+auto CheckList::advanceCurrentLine() -> void {
+    if (currentLine_ >= lines_.size()) {
+        return;
+    }
+    const std::shared_ptr<CheckListLine> currentLine = lines_.at(currentLine_);
+    currentLine->setIsCurrent(false);
+    currentLine++;
+    if (currentLine_ >= lines_.size()) {
+        return;
+    }
+    const std::shared_ptr<CheckListLine> nextLine = lines_.at(currentLine_);
+    nextLine->setIsCurrent(true);
+}
+
+auto CheckList::resetChecklist() -> void {
+    for (const std::shared_ptr<CheckListLine> l : lines_) {
+        l->setCurrentState(CHECKLIST_ITEM_STATE::OPEN);
+    }
+    setCurrentState(CHECKLIST_ITEM_STATE::OPEN);
+}
+
+auto CheckList::checkClosedLoopItems() -> void {
+}
+
+auto CheckList::serviceChecklistUpdateLoop() -> void {
+    checkClosedLoopItems();
+    if(currentLine_ >= lines_.size()) {
+        return;
+    }
+    const std::shared_ptr<CheckListLine> currentLine = lines_.at(currentLine_);
+    if (currentLine->getCurrentState() != CHECKLIST_ITEM_STATE::OPEN) {
+        advanceCurrentLine();
+    }
+}

--- a/B78XH/CheckList.cpp
+++ b/B78XH/CheckList.cpp
@@ -6,6 +6,18 @@ void CheckList::setupControls() {
         serviceChecklistUpdateLoop();
         return true;
     });
+    setupChecklistLayout();
+}
+
+auto CheckList::setupChecklistLayout() -> void {
+    title_->position.setPosition(200, CheckListDimensions::TOTAL_LINE_HEIGHT, 500,
+                                 CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
+    for (auto i = 0; i < lines_.size(); i++) {
+        const std::shared_ptr<CheckListLine> line = lines_.at(i);
+        line->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * i + 2,
+                                   CheckListDimensions::TOTAL_WIDTH,
+                                   CheckListDimensions::TOTAL_LINE_HEIGHT * i + 3);
+    }
 }
 
 auto CheckList::checkChecklistCompleted() -> void {
@@ -46,7 +58,7 @@ auto CheckList::checkClosedLoopItems() -> void {
 
 auto CheckList::serviceChecklistUpdateLoop() -> void {
     checkClosedLoopItems();
-    if(currentLine_ >= lines_.size()) {
+    if (currentLine_ >= lines_.size()) {
         return;
     }
     const std::shared_ptr<CheckListLine> currentLine = lines_.at(currentLine_);

--- a/B78XH/CheckList.cpp
+++ b/B78XH/CheckList.cpp
@@ -26,7 +26,7 @@ auto CheckList::advanceCurrentLine() -> void {
     }
     const std::shared_ptr<CheckListLine> currentLine = lines_.at(currentLine_);
     currentLine->setIsCurrent(false);
-    currentLine++;
+    currentLine_++;
     if (currentLine_ >= lines_.size()) {
         return;
     }

--- a/B78XH/CheckList.cpp
+++ b/B78XH/CheckList.cpp
@@ -24,8 +24,8 @@ auto CheckList::setupChecklistLayout() -> void {
                                    CheckListDimensions::TOTAL_WIDTH,
                                    CheckListDimensions::TOTAL_LINE_HEIGHT * (i + 2));
     }
-    status_->position.setPosition(200, position.getHeight() - CheckListDimensions::TOTAL_LINE_HEIGHT, 500,
-                                  position.getHeight());
+    status_->position.setPosition(200, position.getHeight() - CheckListDimensions::TOTAL_LINE_HEIGHT / 2 - CheckListDimensions::MARGIN, 500,
+                                  position.getHeight() - CheckListDimensions::MARGIN);
 }
 
 auto CheckList::checkChecklistCompleted() -> void {
@@ -35,9 +35,10 @@ auto CheckList::checkChecklistCompleted() -> void {
     for (const std::shared_ptr<CheckListLine> l : lines_) {
         if (l->getCurrentState() == CHECKLIST_ITEM_STATE::OPEN) {
             setCurrentState(CHECKLIST_ITEM_STATE::OPEN);
-            break;
+            return;
         }
     }
+    setCurrentState(CHECKLIST_ITEM_STATE::COMPLETED);
 }
 
 auto CheckList::advanceCurrentLine() -> void {

--- a/B78XH/CheckList.h
+++ b/B78XH/CheckList.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "CheckListItem.h"
+#include "CheckListLine.h"
+
+class CheckList : public CheckListItem {
+    public:
+        CheckList(const string& name)
+            : CheckListItem(name),
+              currentLine_(0) {
+        }
+
+        auto setupControls() -> void override;
+
+    protected:
+        /**
+         * \brief These lines have operational effects and counts towards the checklists overall completeness
+         */
+        const std::vector<std::shared_ptr<CheckListLine>> lines_;
+
+        /**
+         * \brief Evaluates the entire checklists status. This does not care about overridden checklist.
+         */
+        auto checkChecklistCompleted() -> void;
+        /**
+         * \brief Advances the current line pointer. This does not change the checklist's status.
+         */
+        auto advanceCurrentLine() -> void;
+        /**
+         * \brief Resets all checklist lines
+         */
+        auto resetChecklist() -> void;
+        /**
+         * \brief Used to check all closed loop items and set their completeness state.
+         */
+        virtual auto checkClosedLoopItems() -> void;
+
+    private:
+        int currentLine_;
+
+        /**
+         * \brief Invoked periodically to check the checklist
+         */
+        auto serviceChecklistUpdateLoop() -> void;
+};

--- a/B78XH/CheckList.h
+++ b/B78XH/CheckList.h
@@ -1,21 +1,23 @@
 #pragma once
 #include "CheckListItem.h"
 #include "CheckListLine.h"
+#include "CheckListTitle.h"
+#include "CheckListLineSingle.h"
 
 class CheckList : public CheckListItem {
     public:
-        CheckList(const string& name)
+        CheckList(const string& name, const CheckListTitle::TITLE_TYPE titleType, const string& titleText)
             : CheckListItem(name),
-              currentLine_(0) {
+              currentLine_(0), title_(std::make_shared<CheckListTitle>("TITLE", titleType, titleText)) {
         }
 
         auto setupControls() -> void override;
 
     protected:
         /**
-         * \brief These lines have operational effects and counts towards the checklists overall completeness
+         * \brief The lines in this checklist. These lines have operational effects and counts towards the checklists overall completeness
          */
-        const std::vector<std::shared_ptr<CheckListLine>> lines_;
+        std::vector<std::shared_ptr<CheckListLine>> lines_{};
 
         /**
          * \brief Evaluates the entire checklists status. This does not care about overridden checklist.
@@ -33,9 +35,15 @@ class CheckList : public CheckListItem {
          * \brief Used to check all closed loop items and set their completeness state.
          */
         virtual auto checkClosedLoopItems() -> void;
+        /**
+        * \brief Setup layout for a basic checklist with all items in lines_ being 1 line height. This will suffice for most of the checklist.
+        * For special checklist (e.g. with branch items), override this with its own layout.
+        */
+        virtual auto setupChecklistLayout() -> void;
 
     private:
         int currentLine_;
+        const std::shared_ptr<CheckListTitle> title_;
 
         /**
          * \brief Invoked periodically to check the checklist

--- a/B78XH/CheckList.h
+++ b/B78XH/CheckList.h
@@ -3,6 +3,7 @@
 #include "CheckListLine.h"
 #include "CheckListTitle.h"
 #include "CheckListStatus.h"
+#include "CheckListLineSingle.h"
 
 class CheckList : public CheckListItem {
     public:

--- a/B78XH/CheckList.h
+++ b/B78XH/CheckList.h
@@ -2,20 +2,23 @@
 #include "CheckListItem.h"
 #include "CheckListLine.h"
 #include "CheckListTitle.h"
-#include "CheckListLineSingle.h"
+#include "CheckListStatus.h"
 
 class CheckList : public CheckListItem {
     public:
         CheckList(const string& name, const CheckListTitle::TITLE_TYPE titleType, const string& titleText)
             : CheckListItem(name),
-              currentLine_(0), title_(std::make_shared<CheckListTitle>("TITLE", titleType, titleText)) {
+              currentLine_(0), title_(std::make_shared<CheckListTitle>("TITLE", titleType, titleText)),
+              status_(std::make_shared<CheckListStatus>("STATUS", this)) {
         }
 
         auto setupControls() -> void override;
+        auto prepareControls() -> void override;
 
     protected:
         /**
-         * \brief The lines in this checklist. These lines have operational effects and counts towards the checklists overall completeness
+         * \brief The lines in this checklist.
+         * These lines have operational effects and counts towards the checklists overall completeness
          */
         std::vector<std::shared_ptr<CheckListLine>> lines_{};
 
@@ -24,7 +27,7 @@ class CheckList : public CheckListItem {
          */
         auto checkChecklistCompleted() -> void;
         /**
-         * \brief Advances the current line pointer. This does not change the checklist's status.
+         * \brief Advances the current line pointer. This also check if the checklist is completed.
          */
         auto advanceCurrentLine() -> void;
         /**
@@ -36,7 +39,14 @@ class CheckList : public CheckListItem {
          */
         virtual auto checkClosedLoopItems() -> void;
         /**
-        * \brief Setup layout for a basic checklist with all items in lines_ being 1 line height. This will suffice for most of the checklist.
+         * \brief Add controls for a basic checklist with the title and all the item in lines_.
+         * This will suffice for most of the checklist.
+         * For special checklist with more items to render other than these, override this.
+         */
+        virtual auto addChecklistControls() -> void;
+        /**
+        * \brief Setup layout for a basic checklist with all items in lines_ being 1 line height.
+        * This will suffice for most of the checklist.
         * For special checklist (e.g. with branch items), override this with its own layout.
         */
         virtual auto setupChecklistLayout() -> void;
@@ -44,9 +54,15 @@ class CheckList : public CheckListItem {
     private:
         int currentLine_;
         const std::shared_ptr<CheckListTitle> title_;
+        const std::shared_ptr<CheckListStatus> status_;
 
         /**
          * \brief Invoked periodically to check the checklist
          */
         auto serviceChecklistUpdateLoop() -> void;
+        /**
+         * \brief Lower level UI utility. Highlight/Unhighlight the line pointed at currentLine_ if valid.
+         * For normal usage, use advanceCurrentLine, resetChecklist
+         */
+        auto toggleCurrentLineHighlight(bool isCurrent) -> void;
 };

--- a/B78XH/CheckListButton.cpp
+++ b/B78XH/CheckListButton.cpp
@@ -2,7 +2,11 @@
 
 void CheckListButton::render() {
     Control::render();
-    drawButtonBorder();
+    drawButtonBorder(Tools::Colors::cduButtonGray,
+        Tools::Colors::cduButtonBorderTopGray,
+        Tools::Colors::cduButtonBorderRightGray,
+        Tools::Colors::cduButtonBorderBottomGray,
+        Tools::Colors::cduButtonBorderLeftGray);
 
     nvgFontFace(getContext(), "heavy-fmc");
     nvgFontSize(getContext(), 24.0f);
@@ -21,77 +25,4 @@ void CheckListButton::render() {
             invoke_();
         }
     }
-}
-
-auto CheckListButton::drawButtonBorder() -> void {
-    constexpr auto left = 0;
-    constexpr auto top = 0;
-    const auto width = getRelativePosition().getWidth();
-    const auto height = getRelativePosition().getHeight();
-    // open loop indicator
-    nvgFillColor(getContext(), Tools::Colors::cduButtonGray);
-    nvgBeginPath(getContext());
-    {
-        nvgRect(getContext(), 0, 0, width, height);
-        nvgFill(getContext());
-    }
-    nvgClosePath(getContext());
-
-    // top
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderTopGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left, top);
-        nvgLineTo(getContext(), left + width, top);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH, top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left, top);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
-
-    // right
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderRightGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left + width, top);
-        nvgLineTo(getContext(), left + width, top + height + 1);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH + 1);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + width, top);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
-
-    // bottom
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderBottomGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left, top + height);
-        nvgLineTo(getContext(), left + width, top + height);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left, top + height);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
-
-    // left
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderLeftGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left, top);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH, top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left, top + height);
-        nvgLineTo(getContext(), left, top);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
 }

--- a/B78XH/CheckListButton.cpp
+++ b/B78XH/CheckListButton.cpp
@@ -1,23 +1,33 @@
-#include "CheckListLineStateIndicator.h"
-#include "CheckListLine.h"
+#include "CheckListButton.h"
 
-void CheckListLineStateIndicator::drawOpenLoopIndicator() {
+void CheckListButton::render() {
+    Control::render();
+    drawButtonBorder();
+
+    nvgFontFace(getContext(), "heavy-fmc");
+    nvgFontSize(getContext(), 24.0f);
+    nvgFillColor(getContext(), Tools::Colors::white);
+    nvgTextAlign(getContext(), NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    nvgBeginPath(getContext());
+    {
+        nvgText(getContext(), position.width / 2, position.height / 2, displayText_.c_str(), nullptr);
+        nvgFill(getContext());
+    }
+    nvgClosePath(getContext());
+    
+    if (shouldTriggerEvent()) {
+        Console::log("Checklist button triggered {}", displayText_.c_str());
+        if(invoke_ != nullptr) {
+            invoke_();
+        }
+    }
+}
+
+auto CheckListButton::drawButtonBorder() -> void {
     constexpr auto left = 0;
     constexpr auto top = 0;
     const auto width = getRelativePosition().getWidth();
     const auto height = getRelativePosition().getHeight();
-    const auto topGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
-                             ? Tools::Colors::cduButtonBorderBottomGray
-                             : Tools::Colors::cduButtonBorderTopGray;
-    const auto bottomGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
-                                ? Tools::Colors::cduButtonBorderTopGray
-                                : Tools::Colors::cduButtonBorderBottomGray;
-    const auto leftGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
-                              ? Tools::Colors::cduButtonBorderRightGray
-                              : Tools::Colors::cduButtonBorderLeftGray;
-    const auto rightGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
-                               ? Tools::Colors::cduButtonBorderLeftGray
-                               : Tools::Colors::cduButtonBorderRightGray;
     // open loop indicator
     nvgFillColor(getContext(), Tools::Colors::cduButtonGray);
     nvgBeginPath(getContext());
@@ -28,7 +38,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgClosePath(getContext());
 
     // top
-    nvgFillColor(getContext(), topGray);
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderTopGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left, top);
@@ -42,7 +52,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgFill(getContext());
 
     // right
-    nvgFillColor(getContext(), rightGray);
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderRightGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left + width, top);
@@ -57,7 +67,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgFill(getContext());
 
     // bottom
-    nvgFillColor(getContext(), bottomGray);
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderBottomGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left, top + height);
@@ -72,7 +82,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgFill(getContext());
 
     // left
-    nvgFillColor(getContext(), leftGray);
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderLeftGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left, top);
@@ -84,30 +94,4 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     }
     nvgClosePath(getContext());
     nvgFill(getContext());
-}
-
-void CheckListLineStateIndicator::drawCheckMark() {
-    nvgStrokeColor(getContext(), Tools::Colors::green);
-    nvgStrokeWidth(getContext(), 4);
-    nvgBeginPath(getContext());
-    {
-        constexpr float sideOffset = 10;
-        nvgMoveTo(getContext(), sideOffset, 30);
-        nvgLineTo(getContext(), sideOffset+ 12,
-                  position.height - sideOffset);
-        nvgLineTo(getContext(), position.width - sideOffset, sideOffset);
-        nvgStroke(getContext());
-    }
-    nvgClosePath(getContext());
-}
-
-void CheckListLineStateIndicator::render() {
-    Control::render();
-
-    if (line_->line_type == CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP) {
-        drawOpenLoopIndicator();
-    }
-    if (line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED) {
-        drawCheckMark();
-    }
 }

--- a/B78XH/CheckListButton.cpp
+++ b/B78XH/CheckListButton.cpp
@@ -11,10 +11,12 @@ void CheckListButton::render() {
     nvgFontFace(getContext(), "heavy-fmc");
     nvgFontSize(getContext(), 24.0f);
     nvgFillColor(getContext(), Tools::Colors::white);
-    nvgTextAlign(getContext(), NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    nvgTextAlign(getContext(), NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
     nvgBeginPath(getContext());
     {
-        nvgText(getContext(), position.width / 2, position.height / 2, displayText_.c_str(), nullptr);
+        nvgTextBoxBounds(getContext(), 0, position.height / 2, position.width, displayText_.c_str(), nullptr, textBounds_);
+        const auto boundsHeight = textBounds_[3] - textBounds_[1];
+        nvgTextBox(getContext(), 0, position.height / 2 - boundsHeight / 2 + CheckListDimensions::BORDER_WIDTH, position.width, displayText_.c_str(), nullptr);
         nvgFill(getContext());
     }
     nvgClosePath(getContext());

--- a/B78XH/CheckListButton.h
+++ b/B78XH/CheckListButton.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <functional>
+#include "CheckListItem.h"
+#include "Control.h"
+#include "Tools/Console.h"
+
+class CheckListButton : public CheckListItem {
+    public:
+        CheckListButton(const string& name, const std::function<void()>& invoke, const string& displayText)
+            : CheckListItem(name),
+              invoke_(invoke), displayText_(displayText) {
+        }
+
+        auto render() -> void override;
+
+    private:
+        const std::function<void()> invoke_;
+        const string displayText_;
+
+        auto drawButtonBorder() -> void;
+};

--- a/B78XH/CheckListButton.h
+++ b/B78XH/CheckListButton.h
@@ -4,6 +4,9 @@
 #include "Control.h"
 #include "Tools/Console.h"
 
+/**
+ * \brief A clickable button on the checklist. This mostly shows up at the header/footer and in the menus
+ */
 class CheckListButton : public CheckListItem {
     public:
         CheckListButton(const string& name, const std::function<void()>& invoke, const string& displayText)

--- a/B78XH/CheckListButton.h
+++ b/B78XH/CheckListButton.h
@@ -19,6 +19,4 @@ class CheckListButton : public CheckListItem {
     private:
         const std::function<void()> invoke_;
         const string displayText_;
-
-        auto drawButtonBorder() -> void;
 };

--- a/B78XH/CheckListButton.h
+++ b/B78XH/CheckListButton.h
@@ -19,4 +19,5 @@ class CheckListButton : public CheckListItem {
     private:
         const std::function<void()> invoke_;
         const string displayText_;
+        float textBounds_[4] = {0, 0, 0, 0};
 };

--- a/B78XH/CheckListDimensions.h
+++ b/B78XH/CheckListDimensions.h
@@ -6,8 +6,9 @@ class CheckListDimensions {
         static constexpr float TOTAL_WIDTH = 700;  // should match half MFD width
         static constexpr float MARGIN = 8;
         static constexpr float BORDER_WIDTH = 5;
-        static constexpr float INNER_START = MARGIN + BORDER_WIDTH / 2;
-        static constexpr float INNER_HEIGHT = TOTAL_LINE_HEIGHT - 2 * INNER_START;
+        static constexpr float INNER_Y_START = MARGIN + BORDER_WIDTH / 2;
+        static constexpr float INNER_HEIGHT = TOTAL_LINE_HEIGHT - 2 * INNER_Y_START;
         static constexpr float ONE_FORTH_INNER_HEIGHT = INNER_HEIGHT / 4;
-        static constexpr float INNER_Y_END = TOTAL_LINE_HEIGHT - INNER_START;
+        static constexpr float INNER_Y_END = TOTAL_LINE_HEIGHT - INNER_Y_START;
+        static constexpr float INNER_TEXT_X_START = INNER_Y_END + 2 * MARGIN + BORDER_WIDTH / 2;
 };

--- a/B78XH/CheckListDimensions.h
+++ b/B78XH/CheckListDimensions.h
@@ -2,11 +2,12 @@
 
 class CheckListDimensions {
     public:
-        static constexpr float TOTAL_HEIGHT = 50;
+        static constexpr float TOTAL_LINE_HEIGHT = 70;
         static constexpr float TOTAL_WIDTH = 700;  // should match half MFD width
-        static constexpr float MARGIN = 5;
-        static constexpr float INNER_HEIGHT = TOTAL_HEIGHT - 2 * MARGIN;
+        static constexpr float MARGIN = 8;
+        static constexpr float BORDER_WIDTH = 5;
+        static constexpr float INNER_START = MARGIN + BORDER_WIDTH / 2;
+        static constexpr float INNER_HEIGHT = TOTAL_LINE_HEIGHT - 2 * INNER_START;
         static constexpr float ONE_FORTH_INNER_HEIGHT = INNER_HEIGHT / 4;
-        static constexpr float INNER_Y_END = TOTAL_HEIGHT - MARGIN;
-
+        static constexpr float INNER_Y_END = TOTAL_LINE_HEIGHT - INNER_START;
 };

--- a/B78XH/CheckListDimensions.h
+++ b/B78XH/CheckListDimensions.h
@@ -1,0 +1,12 @@
+#pragma once
+
+class CheckListDimensions {
+    public:
+        static constexpr float TOTAL_HEIGHT = 50;
+        static constexpr float TOTAL_WIDTH = 700;  // should match half MFD width
+        static constexpr float MARGIN = 5;
+        static constexpr float INNER_HEIGHT = TOTAL_HEIGHT - 2 * MARGIN;
+        static constexpr float ONE_FORTH_INNER_HEIGHT = INNER_HEIGHT / 4;
+        static constexpr float INNER_Y_END = TOTAL_HEIGHT - MARGIN;
+
+};

--- a/B78XH/CheckListItem.cpp
+++ b/B78XH/CheckListItem.cpp
@@ -1,0 +1,50 @@
+#include "CheckListItem.h"
+
+auto CheckListItem::setCurrentState(CHECKLIST_ITEM_STATE state) -> void {
+    currentState_ = state;
+}
+
+auto CheckListItem::getCurrentState() const -> CHECKLIST_ITEM_STATE {
+    return currentState_;
+}
+
+auto CheckListItem::isInFocus() -> bool {
+    calculateBounds();
+    if (mouseMove_.x >= bounds_[0] &&
+        mouseMove_.x <= bounds_[1] &&
+        mouseMove_.y >= bounds_[2] &&
+        mouseMove_.y < bounds_[3]) {
+        return true;
+    }
+    return false;
+}
+
+auto CheckListItem::getItemStateColor() const -> NVGcolor {
+    switch (currentState_) {
+    case CHECKLIST_ITEM_STATE::OPEN: return Tools::Colors::white;
+    case CHECKLIST_ITEM_STATE::COMPLETED: return Tools::Colors::green;
+    case CHECKLIST_ITEM_STATE::OVERRIDDEN: return Tools::Colors::cyan;
+    default: return Tools::Colors::white;
+    }
+}
+
+auto CheckListItem::drawBorder() -> void {
+    nvgStrokeColor(getContext(), Tools::Colors::magenta);
+    nvgStrokeWidth(getContext(), 5.0f);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), 0, 0);
+        nvgLineTo(getContext(), position.width, 0);
+        nvgLineTo(getContext(),  position.width,  position.height);
+        nvgLineTo(getContext(), 0, position.height);
+        nvgStroke(getContext());
+    }
+    nvgClosePath(getContext());
+}
+
+auto CheckListItem::calculateBounds() -> void {
+    bounds_[0] = absolutePosition.left;
+    bounds_[1] = absolutePosition.left + position.width;
+    bounds_[2] = absolutePosition.top;
+    bounds_[3] = absolutePosition.top + position.height;
+}

--- a/B78XH/CheckListItem.cpp
+++ b/B78XH/CheckListItem.cpp
@@ -1,6 +1,6 @@
 #include "CheckListItem.h"
 
-auto CheckListItem::setCurrentState(CHECKLIST_ITEM_STATE state) -> void {
+auto CheckListItem::setCurrentState(const CHECKLIST_ITEM_STATE state) -> void {
     currentState_ = state;
 }
 
@@ -55,6 +55,80 @@ auto CheckListItem::drawBorder() -> void {
         nvgStroke(getContext());
     }
     nvgClosePath(getContext());
+}
+
+auto CheckListItem::drawButtonBorder(const NVGcolor background, const NVGcolor top, const NVGcolor right, const NVGcolor bottom,
+                                     const NVGcolor left) -> void {
+    constexpr auto leftPos = 0;
+    constexpr auto topPos = 0;
+    const auto width = getRelativePosition().getWidth();
+    const auto height = getRelativePosition().getHeight();
+
+    nvgFillColor(getContext(), background);
+    nvgBeginPath(getContext());
+    {
+        nvgRect(getContext(), 0, 0, width, height);
+        nvgFill(getContext());
+    }
+    nvgClosePath(getContext());
+
+    // top
+    nvgFillColor(getContext(), top);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), leftPos, topPos);
+        nvgLineTo(getContext(), leftPos + width, topPos);
+        nvgLineTo(getContext(), leftPos + width - CheckListDimensions::BORDER_WIDTH,
+                  topPos + CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos + CheckListDimensions::BORDER_WIDTH, topPos + CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos, topPos);
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+
+    // right
+    nvgFillColor(getContext(), right);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), leftPos + width, topPos);
+        nvgLineTo(getContext(), leftPos + width, topPos + height + 1);
+        nvgLineTo(getContext(), leftPos + width - CheckListDimensions::BORDER_WIDTH,
+                  topPos + height - CheckListDimensions::BORDER_WIDTH + 1);
+        nvgLineTo(getContext(), leftPos + width - CheckListDimensions::BORDER_WIDTH,
+                  topPos + CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos + width, topPos);
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+
+    // bottom
+    nvgFillColor(getContext(), bottom);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), leftPos, topPos + height);
+        nvgLineTo(getContext(), leftPos + width, topPos + height);
+        nvgLineTo(getContext(), leftPos + width - CheckListDimensions::BORDER_WIDTH,
+                  topPos + height - CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos + CheckListDimensions::BORDER_WIDTH,
+                  topPos + height - CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos, topPos + height);
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+
+    // left
+    nvgFillColor(getContext(), left);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), leftPos, topPos);
+        nvgLineTo(getContext(), leftPos + CheckListDimensions::BORDER_WIDTH, topPos + CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos + CheckListDimensions::BORDER_WIDTH,
+                  topPos + height - CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), leftPos, topPos + height);
+        nvgLineTo(getContext(), leftPos, topPos);
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
 }
 
 auto CheckListItem::calculateBounds() -> void {

--- a/B78XH/CheckListItem.cpp
+++ b/B78XH/CheckListItem.cpp
@@ -19,6 +19,17 @@ auto CheckListItem::isInFocus() -> bool {
     return false;
 }
 
+auto CheckListItem::shouldTriggerEvent() -> bool {
+    calculateBounds();
+    if (mouseClick_.x >= bounds_[0] &&
+        mouseClick_.x <= bounds_[1] &&
+        mouseClick_.y >= bounds_[2] &&
+        mouseClick_.y <= bounds_[3]) {
+        return true;
+    }
+    return false;
+}
+
 auto CheckListItem::getItemStateColor() const -> NVGcolor {
     switch (currentState_) {
     case CHECKLIST_ITEM_STATE::OPEN: return Tools::Colors::white;

--- a/B78XH/CheckListItem.cpp
+++ b/B78XH/CheckListItem.cpp
@@ -30,13 +30,17 @@ auto CheckListItem::getItemStateColor() const -> NVGcolor {
 
 auto CheckListItem::drawBorder() -> void {
     nvgStrokeColor(getContext(), Tools::Colors::magenta);
-    nvgStrokeWidth(getContext(), 5.0f);
+    nvgStrokeWidth(getContext(), CheckListDimensions::BORDER_WIDTH);
     nvgBeginPath(getContext());
     {
-        nvgMoveTo(getContext(), 0, 0);
-        nvgLineTo(getContext(), position.width, 0);
-        nvgLineTo(getContext(),  position.width,  position.height);
-        nvgLineTo(getContext(), 0, position.height);
+        nvgMoveTo(getContext(), CheckListDimensions::BORDER_WIDTH / 2, CheckListDimensions::BORDER_WIDTH / 2);
+        nvgLineTo(getContext(), position.width - CheckListDimensions::BORDER_WIDTH / 2,
+                  CheckListDimensions::BORDER_WIDTH / 2);
+        nvgLineTo(getContext(), position.width - CheckListDimensions::BORDER_WIDTH / 2,
+                  position.height - CheckListDimensions::BORDER_WIDTH / 2);
+        nvgLineTo(getContext(), CheckListDimensions::BORDER_WIDTH / 2,
+                  position.height - CheckListDimensions::BORDER_WIDTH / 2);
+        nvgLineTo(getContext(), CheckListDimensions::BORDER_WIDTH / 2, CheckListDimensions::BORDER_WIDTH / 2);
         nvgStroke(getContext());
     }
     nvgClosePath(getContext());

--- a/B78XH/CheckListItem.h
+++ b/B78XH/CheckListItem.h
@@ -4,7 +4,7 @@
 #include "CheckListDimensions.h"
 
 /**
-* \brief  An abstract representation of an "item" on the checklist. An Item simply has a "CHECKLIST_ITEM_STATE"
+* \brief  An abstract representation of an "item" on the checklist. An Item simply has a "CHECKLIST_ITEM_STATE" and utility UI functions.
  */
 class CheckListItem : public Control {
     public:
@@ -41,13 +41,22 @@ class CheckListItem : public Control {
         auto shouldTriggerEvent() -> bool;
         /**
          * \brief Gets the color corresponding to the current state.
-         * \return Desired color.
          */
         auto getItemStateColor() const -> NVGcolor;
         /**
-         * \brief Draws a magenta border around the item
+         * \brief Draws a magenta border around the item.
          */
         auto drawBorder() -> void;
+
+        /**
+         * \brief Draws a button-like boarder around the item.
+         * \param background Background fill color.
+         * \param top Top boarder color.
+         * \param right Right boarder color.
+         * \param bottom Bottom boarder color.
+         * \param left Left boarder color.
+         */
+        auto drawButtonBorder(NVGcolor background, NVGcolor top, NVGcolor right, NVGcolor bottom, NVGcolor left) -> void;
 
     private:
         /**

--- a/B78XH/CheckListItem.h
+++ b/B78XH/CheckListItem.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Control.h"
 #include "Tools/Tools.h"
+#include "CheckListDimensions.h"
 
 /**
 * \brief  An abstract representation of an "item" on the checklist. An Item simply has a "CHECKLIST_ITEM_STATE"

--- a/B78XH/CheckListItem.h
+++ b/B78XH/CheckListItem.h
@@ -27,6 +27,10 @@ class CheckListItem : public Control {
         * \brief Gets the current state of the item.
         */
         auto getCurrentState() const -> CHECKLIST_ITEM_STATE;
+        /**
+        * \brief Gets the color corresponding to the current state.
+        */
+        auto getItemStateColor() const -> NVGcolor;
 
     protected:
         /**
@@ -39,10 +43,6 @@ class CheckListItem : public Control {
          * \return true if mouse is clicking, false otherwise
          */
         auto shouldTriggerEvent() -> bool;
-        /**
-         * \brief Gets the color corresponding to the current state.
-         */
-        auto getItemStateColor() const -> NVGcolor;
         /**
          * \brief Draws a magenta border around the item.
          */

--- a/B78XH/CheckListItem.h
+++ b/B78XH/CheckListItem.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "Control.h"
+#include "Tools/Tools.h"
+
+/**
+* \brief  An abstract representation of an "item" on the checklist. An Item simply has a "CHECKLIST_ITEM_STATE"
+ */
+class CheckListItem : public Control {
+    public:
+        enum class CHECKLIST_ITEM_STATE {
+            OPEN,
+            COMPLETED,
+            OVERRIDDEN
+        };
+
+        CheckListItem(const string& name)
+            : Control(name),
+              currentState_(CHECKLIST_ITEM_STATE::OPEN) {
+        }
+
+        /**
+         * \brief Sets the item to the desired state.
+         */
+        auto setCurrentState(CHECKLIST_ITEM_STATE state) -> void;
+        /**
+        * \brief Gets the current state of the item.
+        */
+        auto getCurrentState() const -> CHECKLIST_ITEM_STATE;
+
+    protected:
+        /**
+         * \brief Checks if the item is being hovered by the cursor.
+         * \return true if in focus, false otherwise
+         */
+        auto isInFocus() -> bool;
+        /**
+         * \brief Gets the color corresponding to the current state.
+         * \return Desired color.
+         */
+        auto getItemStateColor() const -> NVGcolor;
+        /**
+         * \brief Draws a magenta border around the item
+         */
+        auto drawBorder() -> void;
+
+    private:
+        /**
+         * \brief The item's current state.
+         */
+        CHECKLIST_ITEM_STATE currentState_;
+        /**
+         * \brief The item's bound in absolute space. Order is LRTB.
+         */
+        float bounds_[4] = {0, 0, 0, 0};
+        /**
+         * \brief Updates bounds_ with the current absolute position.
+         */
+        auto calculateBounds() -> void;
+};

--- a/B78XH/CheckListItem.h
+++ b/B78XH/CheckListItem.h
@@ -35,6 +35,11 @@ class CheckListItem : public Control {
          */
         auto isInFocus() -> bool;
         /**
+         * \brief Checks if mouse is clicking on this item
+         * \return true if mouse is clicking, false otherwise
+         */
+        auto shouldTriggerEvent() -> bool;
+        /**
          * \brief Gets the color corresponding to the current state.
          * \return Desired color.
          */

--- a/B78XH/CheckListLine.cpp
+++ b/B78XH/CheckListLine.cpp
@@ -20,8 +20,6 @@ void CheckListLine::render() {
 
 void CheckListLine::prepareControls() {
     CheckListItem::prepareControls();
-
-    stateIndicator_ = std::make_shared<CheckListLineStateIndicator>("STATE_INDICATOR", this);
     add(stateIndicator_);
 }
 

--- a/B78XH/CheckListLine.cpp
+++ b/B78XH/CheckListLine.cpp
@@ -9,5 +9,5 @@ void CheckListLine::prepareControls() {
 void CheckListLine::setupControls() {
     CheckListItem::setupControls();
 
-    getControl("STATE_INDICATOR")->position.setPosition(CheckListDimensions::LINE_MARGIN, CheckListDimensions::LINE_MARGIN, CheckListDimensions::INNER_LINE_END_Y, CheckListDimensions::INNER_LINE_END_Y);
+    getControl("STATE_INDICATOR")->position.setPosition(CheckListDimensions::MARGIN, CheckListDimensions::MARGIN, CheckListDimensions::INNER_Y_END, CheckListDimensions::INNER_Y_END);
 }

--- a/B78XH/CheckListLine.cpp
+++ b/B78XH/CheckListLine.cpp
@@ -13,8 +13,11 @@ void CheckListLine::render() {
     if (isInFocus()) {
         drawBorder();
     }
-    if(isCurrent_) {
+    if (isCurrent_) {
         drawIsCurrentBorder();
+    }
+    if (shouldTriggerEvent()) {
+        setCurrentState(CHECKLIST_ITEM_STATE::COMPLETED);
     }
 }
 

--- a/B78XH/CheckListLine.cpp
+++ b/B78XH/CheckListLine.cpp
@@ -1,20 +1,52 @@
 #include "CheckListLine.h"
 
+auto CheckListLine::setIsCurrent(bool current) -> void {
+    isCurrent_ = current;
+}
+
+auto CheckListLine::getIsCurrent() const -> bool {
+    return isCurrent_;
+}
+
 void CheckListLine::render() {
     CheckListItem::render();
-    if(isInFocus()) {
+    if (isInFocus()) {
         drawBorder();
+    }
+    if(isCurrent_) {
+        drawIsCurrentBorder();
     }
 }
 
 void CheckListLine::prepareControls() {
     CheckListItem::prepareControls();
 
-    add(std::make_shared<CheckListLineStateIndicator>("STATE_INDICATOR", this));
+    stateIndicator_ = std::make_shared<CheckListLineStateIndicator>("STATE_INDICATOR", this);
+    add(stateIndicator_);
 }
 
 void CheckListLine::setupControls() {
     CheckListItem::setupControls();
 
-    getControl("STATE_INDICATOR")->position.setPosition(CheckListDimensions::MARGIN, CheckListDimensions::MARGIN, CheckListDimensions::INNER_Y_END, CheckListDimensions::INNER_Y_END);
+    stateIndicator_->position.setPosition(CheckListDimensions::MARGIN, CheckListDimensions::MARGIN,
+                                          CheckListDimensions::INNER_Y_END, CheckListDimensions::INNER_Y_END);
+}
+
+auto CheckListLine::drawIsCurrentBorder() -> void {
+    const float xStart = CheckListDimensions::INNER_Y_END + CheckListDimensions::MARGIN;
+    const float xEnd = position.width - CheckListDimensions::BORDER_WIDTH - CheckListDimensions::MARGIN;
+    const float yStart = CheckListDimensions::BORDER_WIDTH / 2 + CheckListDimensions::MARGIN;
+    const float yEnd = position.height - CheckListDimensions::BORDER_WIDTH - CheckListDimensions::MARGIN;
+    nvgStrokeColor(getContext(), Tools::Colors::white);
+    nvgStrokeWidth(getContext(), CheckListDimensions::BORDER_WIDTH);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), xStart, yStart);
+        nvgLineTo(getContext(), xStart, yEnd);
+        nvgLineTo(getContext(), xEnd, yEnd);
+        nvgLineTo(getContext(), xEnd, yStart);
+        nvgLineTo(getContext(), xStart, yStart);
+        nvgStroke(getContext());
+    }
+    nvgClosePath(getContext());
 }

--- a/B78XH/CheckListLine.cpp
+++ b/B78XH/CheckListLine.cpp
@@ -1,5 +1,12 @@
 #include "CheckListLine.h"
 
+void CheckListLine::render() {
+    CheckListItem::render();
+    if(isInFocus()) {
+        drawBorder();
+    }
+}
+
 void CheckListLine::prepareControls() {
     CheckListItem::prepareControls();
 

--- a/B78XH/CheckListLine.cpp
+++ b/B78XH/CheckListLine.cpp
@@ -1,0 +1,13 @@
+#include "CheckListLine.h"
+
+void CheckListLine::prepareControls() {
+    CheckListItem::prepareControls();
+
+    add(std::make_shared<CheckListLineStateIndicator>("STATE_INDICATOR", this));
+}
+
+void CheckListLine::setupControls() {
+    CheckListItem::setupControls();
+
+    getControl("STATE_INDICATOR")->position.setPosition(CheckListDimensions::LINE_MARGIN, CheckListDimensions::LINE_MARGIN, CheckListDimensions::INNER_LINE_END_Y, CheckListDimensions::INNER_LINE_END_Y);
+}

--- a/B78XH/CheckListLine.h
+++ b/B78XH/CheckListLine.h
@@ -19,7 +19,8 @@ class CheckListLine : public CheckListItem {
         }
 
         const CHECKLIST_LINE_TYPE line_type;
-    
+
+        auto render() -> void override;
         auto prepareControls() -> void override;
         auto setupControls() -> void override;
 };

--- a/B78XH/CheckListLine.h
+++ b/B78XH/CheckListLine.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CheckListItem.h"
+#include "CheckListLineStateIndicator.h"
+
+/**
+ * \brief A line in the check list. This typically consists of 1 "LineStateIndicator" and several "CheckListItem" 
+ */
+class CheckListLine : public CheckListItem {
+    public:
+        enum class CHECKLIST_LINE_TYPE {
+            OPEN_LOOP,
+            CLOSED_LOOP
+        };
+
+        CheckListLine(const string& name, const CHECKLIST_LINE_TYPE line_type)
+            : CheckListItem(name),
+              line_type(line_type) {
+        }
+
+        const CHECKLIST_LINE_TYPE line_type;
+    
+        auto prepareControls() -> void override;
+        auto setupControls() -> void override;
+};

--- a/B78XH/CheckListLine.h
+++ b/B78XH/CheckListLine.h
@@ -27,7 +27,7 @@ class CheckListLine : public CheckListItem {
         auto setupControls() -> void override;
 
     private:
-        std::shared_ptr<CheckListLineStateIndicator> stateIndicator_;
+        std::shared_ptr<CheckListLineStateIndicator> stateIndicator_ = std::make_shared<CheckListLineStateIndicator>("STATE_INDICATOR", this);
         bool isCurrent_;
 
         auto drawIsCurrentBorder() -> void;

--- a/B78XH/CheckListLine.h
+++ b/B78XH/CheckListLine.h
@@ -15,12 +15,20 @@ class CheckListLine : public CheckListItem {
 
         CheckListLine(const string& name, const CHECKLIST_LINE_TYPE line_type)
             : CheckListItem(name),
-              line_type(line_type) {
+              line_type(line_type), isCurrent_(false) {
         }
 
         const CHECKLIST_LINE_TYPE line_type;
 
+        auto setIsCurrent(bool current) -> void;
+        auto getIsCurrent() const -> bool;
         auto render() -> void override;
         auto prepareControls() -> void override;
         auto setupControls() -> void override;
+
+    private:
+        std::shared_ptr<CheckListLineStateIndicator> stateIndicator_;
+        bool isCurrent_;
+
+        auto drawIsCurrentBorder() -> void;
 };

--- a/B78XH/CheckListLineSingle.cpp
+++ b/B78XH/CheckListLineSingle.cpp
@@ -1,0 +1,17 @@
+#include "CheckListLineSingle.h"
+
+void CheckListLineSingle::render() {
+    CheckListLine::render();
+
+    nvgFillColor(getContext(), getItemStateColor());
+    nvgFontFace(getContext(), "roboto");
+    nvgFontSize(getContext(), 38.0f);
+    nvgTextAlign(getContext(), NVG_ALIGN_MIDDLE | NVG_ALIGN_LEFT);
+    nvgBeginPath(getContext());
+    {
+        nvgText(getContext(), CheckListDimensions::INNER_TEXT_X_START, position.height / 2, textDisplayed_.c_str(),
+                nullptr);
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+}

--- a/B78XH/CheckListLineSingle.h
+++ b/B78XH/CheckListLineSingle.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "CheckListLine.h"
+
+/**
+ * \brief Specialized to render a checklist line that's just "single line".
+ * This is so common that it deserves it's own class.
+ */
+class CheckListLineSingle : public CheckListLine {
+    public:
+        CheckListLineSingle(const string& name, CHECKLIST_LINE_TYPE line_type, const string& textDisplayed)
+            : CheckListLine(name, line_type),
+              textDisplayed_(textDisplayed){
+        }
+
+        auto render() -> void override;
+    private:
+        const string textDisplayed_;
+};

--- a/B78XH/CheckListLineStateIndicator.cpp
+++ b/B78XH/CheckListLineStateIndicator.cpp
@@ -1,22 +1,99 @@
 #include "CheckListLineStateIndicator.h"
 #include "CheckListLine.h"
 
+void CheckListLineStateIndicator::drawOpenLoopIndicator() {
+    constexpr auto left = 0;
+    constexpr auto top = 0;
+    const auto width = getRelativePosition().getWidth();
+    const auto height = getRelativePosition().getHeight();
+    // open loop indicator
+    nvgFillColor(getContext(), Tools::Colors::cduButtonGray);
+    nvgBeginPath(getContext());
+    {
+        nvgRect(getContext(), 0, 0, width, height);
+        nvgFill(getContext());
+    }
+    nvgClosePath(getContext());
+    
+    // top
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderTopGray);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), left, top);
+        nvgLineTo(getContext(), (left + width), top);
+        nvgLineTo(getContext(), (left + width - CheckListDimensions::BORDER_WIDTH),
+                  (top + CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), (left + CheckListDimensions::BORDER_WIDTH), (top + CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), left, top);
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+
+    // right
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderRightGray);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), (left + width), top);
+        nvgLineTo(getContext(), (left + width), (top + height) + 1);
+        nvgLineTo(getContext(), (left + width - CheckListDimensions::BORDER_WIDTH),
+                  (top + height - CheckListDimensions::BORDER_WIDTH) + 1);
+        nvgLineTo(getContext(), (left + width - CheckListDimensions::BORDER_WIDTH),
+                  (top + CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), (left + width), (top));
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+
+    // bottom
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderBottomGray);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), left, (top + height));
+        nvgLineTo(getContext(), (left + width), (top + height));
+        nvgLineTo(getContext(), (left + width - CheckListDimensions::BORDER_WIDTH),
+                  (top + height - CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), (left + CheckListDimensions::BORDER_WIDTH),
+                  (top + height - CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), (left), (top + height));
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+
+    // left
+    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderLeftGray);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), left, top);
+        nvgLineTo(getContext(), (left + CheckListDimensions::BORDER_WIDTH), (top + CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), (left + CheckListDimensions::BORDER_WIDTH),
+                  (top + height - CheckListDimensions::BORDER_WIDTH));
+        nvgLineTo(getContext(), (left), (top + height));
+        nvgLineTo(getContext(), (left), (top));
+    }
+    nvgClosePath(getContext());
+    nvgFill(getContext());
+}
+
+void CheckListLineStateIndicator::drawCheckMark() {
+    nvgStrokeColor(getContext(), Tools::Colors::green);
+    nvgStrokeWidth(getContext(), 3);
+    nvgBeginPath(getContext());
+    {
+        nvgMoveTo(getContext(), CheckListDimensions::BORDER_WIDTH, 25);
+        nvgLineTo(getContext(), CheckListDimensions::BORDER_WIDTH + 15,
+                  position.height - CheckListDimensions::BORDER_WIDTH);
+        nvgLineTo(getContext(), position.width - CheckListDimensions::BORDER_WIDTH, CheckListDimensions::BORDER_WIDTH);
+        nvgStroke(getContext());
+    }
+    nvgClosePath(getContext());
+}
+
 void CheckListLineStateIndicator::render() {
     CheckListItem::render();
 
     if (line_->line_type == CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP) {
+        drawOpenLoopIndicator();
     }
-    else {
-        // green check, testing
-        nvgStrokeColor(getContext(), Tools::Colors::green);
-        nvgStrokeWidth(getContext(), 3);
-        nvgBeginPath(getContext());
-        {
-            nvgMoveTo(getContext(), CheckListDimensions::MARGIN, CheckListDimensions::ONE_FORTH_INNER_HEIGHT * 3);
-            nvgLineTo(getContext(), CheckListDimensions::MARGIN + CheckListDimensions::ONE_FORTH_INNER_HEIGHT, CheckListDimensions::INNER_Y_END);
-            nvgLineTo(getContext(),  CheckListDimensions::MARGIN + CheckListDimensions::ONE_FORTH_INNER_HEIGHT * 3, CheckListDimensions::MARGIN);
-            nvgStroke(getContext());
-        }
-        nvgClosePath(getContext());
-    }
+    // green check, testing
+    drawCheckMark();
 }

--- a/B78XH/CheckListLineStateIndicator.cpp
+++ b/B78XH/CheckListLineStateIndicator.cpp
@@ -1,89 +1,19 @@
-#include "CheckListLineStateIndicator.h"
 #include "CheckListLine.h"
 
 void CheckListLineStateIndicator::drawOpenLoopIndicator() {
-    constexpr auto left = 0;
-    constexpr auto top = 0;
-    const auto width = getRelativePosition().getWidth();
-    const auto height = getRelativePosition().getHeight();
-    const auto topGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+    const auto topGray = line_->getCurrentState() == CHECKLIST_ITEM_STATE::COMPLETED
                              ? Tools::Colors::cduButtonBorderBottomGray
                              : Tools::Colors::cduButtonBorderTopGray;
-    const auto bottomGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+    const auto bottomGray = line_->getCurrentState() == CHECKLIST_ITEM_STATE::COMPLETED
                                 ? Tools::Colors::cduButtonBorderTopGray
                                 : Tools::Colors::cduButtonBorderBottomGray;
-    const auto leftGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+    const auto leftGray = line_->getCurrentState() == CHECKLIST_ITEM_STATE::COMPLETED
                               ? Tools::Colors::cduButtonBorderRightGray
                               : Tools::Colors::cduButtonBorderLeftGray;
-    const auto rightGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+    const auto rightGray = line_->getCurrentState() == CHECKLIST_ITEM_STATE::COMPLETED
                                ? Tools::Colors::cduButtonBorderLeftGray
                                : Tools::Colors::cduButtonBorderRightGray;
-    // open loop indicator
-    nvgFillColor(getContext(), Tools::Colors::cduButtonGray);
-    nvgBeginPath(getContext());
-    {
-        nvgRect(getContext(), 0, 0, width, height);
-        nvgFill(getContext());
-    }
-    nvgClosePath(getContext());
-
-    // top
-    nvgFillColor(getContext(), topGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left, top);
-        nvgLineTo(getContext(), left + width, top);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH, top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left, top);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
-
-    // right
-    nvgFillColor(getContext(), rightGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left + width, top);
-        nvgLineTo(getContext(), left + width, top + height + 1);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH + 1);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + width, top);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
-
-    // bottom
-    nvgFillColor(getContext(), bottomGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left, top + height);
-        nvgLineTo(getContext(), left + width, top + height);
-        nvgLineTo(getContext(), left + width - CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left, top + height);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
-
-    // left
-    nvgFillColor(getContext(), leftGray);
-    nvgBeginPath(getContext());
-    {
-        nvgMoveTo(getContext(), left, top);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH, top + CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left + CheckListDimensions::BORDER_WIDTH,
-                  top + height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), left, top + height);
-        nvgLineTo(getContext(), left, top);
-    }
-    nvgClosePath(getContext());
-    nvgFill(getContext());
+    drawButtonBorder(Tools::Colors::cduButtonGray, topGray, rightGray, bottomGray, leftGray);
 }
 
 void CheckListLineStateIndicator::drawCheckMark() {
@@ -102,7 +32,7 @@ void CheckListLineStateIndicator::drawCheckMark() {
 }
 
 void CheckListLineStateIndicator::render() {
-    Control::render();
+    CheckListItem::render();
 
     if (line_->line_type == CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP) {
         drawOpenLoopIndicator();

--- a/B78XH/CheckListLineStateIndicator.cpp
+++ b/B78XH/CheckListLineStateIndicator.cpp
@@ -1,0 +1,22 @@
+#include "CheckListLineStateIndicator.h"
+#include "CheckListLine.h"
+
+void CheckListLineStateIndicator::render() {
+    CheckListItem::render();
+
+    if (line_->line_type == CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP) {
+    }
+    else {
+        // green check, testing
+        nvgStrokeColor(getContext(), Tools::Colors::green);
+        nvgStrokeWidth(getContext(), 3);
+        nvgBeginPath(getContext());
+        {
+            nvgMoveTo(getContext(), CheckListDimensions::LINE_MARGIN, CheckListDimensions::ONE_FORTH_INNER_LINE_HEIGHT * 3);
+            nvgLineTo(getContext(), CheckListDimensions::LINE_MARGIN + CheckListDimensions::ONE_FORTH_INNER_LINE_HEIGHT, CheckListDimensions::INNER_LINE_END_Y);
+            nvgLineTo(getContext(),  CheckListDimensions::LINE_MARGIN + CheckListDimensions::ONE_FORTH_INNER_LINE_HEIGHT * 3, CheckListDimensions::LINE_MARGIN);
+            nvgStroke(getContext());
+        }
+        nvgClosePath(getContext());
+    }
+}

--- a/B78XH/CheckListLineStateIndicator.cpp
+++ b/B78XH/CheckListLineStateIndicator.cpp
@@ -12,9 +12,9 @@ void CheckListLineStateIndicator::render() {
         nvgStrokeWidth(getContext(), 3);
         nvgBeginPath(getContext());
         {
-            nvgMoveTo(getContext(), CheckListDimensions::LINE_MARGIN, CheckListDimensions::ONE_FORTH_INNER_LINE_HEIGHT * 3);
-            nvgLineTo(getContext(), CheckListDimensions::LINE_MARGIN + CheckListDimensions::ONE_FORTH_INNER_LINE_HEIGHT, CheckListDimensions::INNER_LINE_END_Y);
-            nvgLineTo(getContext(),  CheckListDimensions::LINE_MARGIN + CheckListDimensions::ONE_FORTH_INNER_LINE_HEIGHT * 3, CheckListDimensions::LINE_MARGIN);
+            nvgMoveTo(getContext(), CheckListDimensions::MARGIN, CheckListDimensions::ONE_FORTH_INNER_HEIGHT * 3);
+            nvgLineTo(getContext(), CheckListDimensions::MARGIN + CheckListDimensions::ONE_FORTH_INNER_HEIGHT, CheckListDimensions::INNER_Y_END);
+            nvgLineTo(getContext(),  CheckListDimensions::MARGIN + CheckListDimensions::ONE_FORTH_INNER_HEIGHT * 3, CheckListDimensions::MARGIN);
             nvgStroke(getContext());
         }
         nvgClosePath(getContext());

--- a/B78XH/CheckListLineStateIndicator.cpp
+++ b/B78XH/CheckListLineStateIndicator.cpp
@@ -6,6 +6,18 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     constexpr auto top = 0;
     const auto width = getRelativePosition().getWidth();
     const auto height = getRelativePosition().getHeight();
+    const auto topGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+                             ? Tools::Colors::cduButtonBorderBottomGray
+                             : Tools::Colors::cduButtonBorderTopGray;
+    const auto bottomGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+                                ? Tools::Colors::cduButtonBorderTopGray
+                                : Tools::Colors::cduButtonBorderBottomGray;
+    const auto leftGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+                              ? Tools::Colors::cduButtonBorderRightGray
+                              : Tools::Colors::cduButtonBorderLeftGray;
+    const auto rightGray = line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED
+                               ? Tools::Colors::cduButtonBorderLeftGray
+                               : Tools::Colors::cduButtonBorderRightGray;
     // open loop indicator
     nvgFillColor(getContext(), Tools::Colors::cduButtonGray);
     nvgBeginPath(getContext());
@@ -14,9 +26,9 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
         nvgFill(getContext());
     }
     nvgClosePath(getContext());
-    
+
     // top
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderTopGray);
+    nvgFillColor(getContext(), topGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left, top);
@@ -30,7 +42,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgFill(getContext());
 
     // right
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderRightGray);
+    nvgFillColor(getContext(), rightGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), (left + width), top);
@@ -45,7 +57,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgFill(getContext());
 
     // bottom
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderBottomGray);
+    nvgFillColor(getContext(), bottomGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left, (top + height));
@@ -60,7 +72,7 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
     nvgFill(getContext());
 
     // left
-    nvgFillColor(getContext(), Tools::Colors::cduButtonBorderLeftGray);
+    nvgFillColor(getContext(), leftGray);
     nvgBeginPath(getContext());
     {
         nvgMoveTo(getContext(), left, top);
@@ -76,24 +88,26 @@ void CheckListLineStateIndicator::drawOpenLoopIndicator() {
 
 void CheckListLineStateIndicator::drawCheckMark() {
     nvgStrokeColor(getContext(), Tools::Colors::green);
-    nvgStrokeWidth(getContext(), 3);
+    nvgStrokeWidth(getContext(), 4);
     nvgBeginPath(getContext());
     {
-        nvgMoveTo(getContext(), CheckListDimensions::BORDER_WIDTH, 25);
-        nvgLineTo(getContext(), CheckListDimensions::BORDER_WIDTH + 15,
-                  position.height - CheckListDimensions::BORDER_WIDTH);
-        nvgLineTo(getContext(), position.width - CheckListDimensions::BORDER_WIDTH, CheckListDimensions::BORDER_WIDTH);
+        constexpr float sideOffset = 10;
+        nvgMoveTo(getContext(), sideOffset, 30);
+        nvgLineTo(getContext(), sideOffset+ 12,
+                  position.height - sideOffset);
+        nvgLineTo(getContext(), position.width - sideOffset, sideOffset);
         nvgStroke(getContext());
     }
     nvgClosePath(getContext());
 }
 
 void CheckListLineStateIndicator::render() {
-    CheckListItem::render();
+    Control::render();
 
     if (line_->line_type == CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP) {
         drawOpenLoopIndicator();
     }
-    // green check, testing
-    drawCheckMark();
+    if (line_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED) {
+        drawCheckMark();
+    }
 }

--- a/B78XH/CheckListLineStateIndicator.h
+++ b/B78XH/CheckListLineStateIndicator.h
@@ -7,10 +7,10 @@ class CheckListLine;
 /**
  * \brief The main state indicator of a "line" in a checklist. This is typically the "checkbox"/"checkmark". Internal, Owned by "CheckListLine"
  */
-class CheckListLineStateIndicator : public Control {
+class CheckListLineStateIndicator : public CheckListItem {
     public:
         CheckListLineStateIndicator(const string& name, const CheckListLine* parentLine)
-            : Control(name),
+            : CheckListItem(name),
                 line_(parentLine){
         }
 

--- a/B78XH/CheckListLineStateIndicator.h
+++ b/B78XH/CheckListLineStateIndicator.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "CheckListItem.h"
+#include "CheckListDimensions.h"
+
+class CheckListLine;
+
+/**
+ * \brief The main state indicator of a "line" in a checklist. This is typically the "checkbox"/"checkmark". Internal, Owned by "CheckListLine"
+ */
+class CheckListLineStateIndicator : public CheckListItem {
+    public:
+        CheckListLineStateIndicator(const string& name, const CheckListLine* parentLine)
+            : CheckListItem(name),
+                line_(parentLine){
+        }
+
+        auto render() -> void override;
+
+    private:
+        const CheckListLine* line_;     // weak_ptr here?
+};

--- a/B78XH/CheckListLineStateIndicator.h
+++ b/B78XH/CheckListLineStateIndicator.h
@@ -7,10 +7,10 @@ class CheckListLine;
 /**
  * \brief The main state indicator of a "line" in a checklist. This is typically the "checkbox"/"checkmark". Internal, Owned by "CheckListLine"
  */
-class CheckListLineStateIndicator : public CheckListItem {
+class CheckListLineStateIndicator : public Control {
     public:
         CheckListLineStateIndicator(const string& name, const CheckListLine* parentLine)
-            : CheckListItem(name),
+            : Control(name),
                 line_(parentLine){
         }
 

--- a/B78XH/CheckListLineStateIndicator.h
+++ b/B78XH/CheckListLineStateIndicator.h
@@ -18,4 +18,7 @@ class CheckListLineStateIndicator : public CheckListItem {
 
     private:
         const CheckListLine* line_;     // weak_ptr here?
+
+        auto drawOpenLoopIndicator() -> void;
+        auto drawCheckMark() -> void;
 };

--- a/B78XH/CheckListStatus.cpp
+++ b/B78XH/CheckListStatus.cpp
@@ -1,0 +1,27 @@
+#include "CheckListStatus.h"
+#include "CheckList.h"
+
+void CheckListStatus::render() {
+    Control::render();
+    const auto color = parentChecklist_->getItemStateColor();
+    const auto displayText = parentChecklist_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::OVERRIDDEN
+                                 ? "CHECKLIST OVERRIDDEN"
+                                 : "CHECKLIST COMPLETE";
+    nvgFillColor(getContext(), color);
+    nvgBeginPath(getContext());
+    {
+        nvgRoundedRect(getContext(), 0, 0, position.getWidth(), position.getHeight(), position.getHeight() / 2);
+        nvgFill(getContext());
+    }
+    nvgClosePath(getContext());
+    nvgFontFace(getContext(), "heavy-mfc");
+    nvgFontSize(getContext(), 24);
+    nvgFillColor(getContext(), Tools::Colors::white);
+    nvgTextAlign(getContext(), NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    nvgBeginPath(getContext());
+    {
+        nvgText(getContext(), position.getWidth() / 2, position.getHeight() / 2, displayText, nullptr);
+        nvgFill(getContext());
+    }
+    nvgClosePath(getContext());
+}

--- a/B78XH/CheckListStatus.cpp
+++ b/B78XH/CheckListStatus.cpp
@@ -10,7 +10,7 @@ void CheckListStatus::render() {
     const auto color = parentChecklist_->getItemStateColor();
     const auto displayText = currentState == CheckListItem::CHECKLIST_ITEM_STATE::OVERRIDDEN
                                  ? "CHECKLIST OVERRIDDEN"
-                                 : "CHECKLIST COMPLETE";
+                                 : "CHECKLIST COMPLETED";
     nvgFillColor(getContext(), color);
     nvgBeginPath(getContext());
     {
@@ -18,7 +18,7 @@ void CheckListStatus::render() {
         nvgFill(getContext());
     }
     nvgClosePath(getContext());
-    nvgFontFace(getContext(), "heavy-mfc");
+    nvgFontFace(getContext(), "heavy-fmc");
     nvgFontSize(getContext(), 24);
     nvgFillColor(getContext(), Tools::Colors::white);
     nvgTextAlign(getContext(), NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);

--- a/B78XH/CheckListStatus.cpp
+++ b/B78XH/CheckListStatus.cpp
@@ -3,8 +3,12 @@
 
 void CheckListStatus::render() {
     Control::render();
+    const auto currentState = parentChecklist_->getCurrentState();
+    if (currentState == CheckListItem::CHECKLIST_ITEM_STATE::OPEN) {
+        return;
+    }
     const auto color = parentChecklist_->getItemStateColor();
-    const auto displayText = parentChecklist_->getCurrentState() == CheckListItem::CHECKLIST_ITEM_STATE::OVERRIDDEN
+    const auto displayText = currentState == CheckListItem::CHECKLIST_ITEM_STATE::OVERRIDDEN
                                  ? "CHECKLIST OVERRIDDEN"
                                  : "CHECKLIST COMPLETE";
     nvgFillColor(getContext(), color);

--- a/B78XH/CheckListStatus.h
+++ b/B78XH/CheckListStatus.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Control.h"
+
+class CheckList;
+
+/**
+ * \brief The overall status indicator on a checklist.
+ */
+class CheckListStatus : public Control {
+    public:
+        CheckListStatus(const string& name, const CheckList* parentChecklist)
+            : Control(name),
+              parentChecklist_(parentChecklist) {
+        }
+
+        auto render() -> void override;
+    private:
+        const CheckList* parentChecklist_;
+};

--- a/B78XH/CheckListTitle.cpp
+++ b/B78XH/CheckListTitle.cpp
@@ -1,0 +1,43 @@
+#include "CheckListTitle.h"
+
+void CheckListTitle::render() {
+    Control::render();
+
+    constexpr float triangleSize = 24;
+    constexpr float halfTriangleSize = triangleSize / 2;
+    const float halfHeight = position.height / 2;
+    const float halfWidth = position.width / 2;
+    nvgFontFace(getContext(), "heavy-fmc");
+    nvgFontSize(getContext(), 28.0f);
+    nvgFillColor(getContext(), type_ == TITLE_TYPE::NON_NORMAL_CHECKLIST ? Tools::Colors::amber : Tools::Colors::white);
+    nvgTextAlign(getContext(), NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+    nvgBeginPath(getContext());
+    {
+        nvgText(getContext(), halfWidth, halfHeight, titleText_.c_str(), nullptr);
+        nvgFill(getContext());
+    }
+    nvgClosePath(getContext());
+    if(type_ != TITLE_TYPE::MENU) {
+        // draw front triangle
+        nvgBeginPath(getContext());
+        {
+            nvgMoveTo(getContext(), 0, halfHeight - halfTriangleSize);
+            nvgLineTo(getContext(), triangleSize, halfHeight);
+            nvgLineTo(getContext(), 0, halfHeight + halfTriangleSize);
+            nvgLineTo(getContext(), 0, halfHeight - halfTriangleSize);
+            nvgFill(getContext());
+        }
+        nvgClosePath(getContext());
+
+        // draw end triangle
+        nvgBeginPath(getContext());
+        {
+            nvgMoveTo(getContext(), position.width, halfHeight - halfTriangleSize);
+            nvgLineTo(getContext(), position.width - triangleSize, halfHeight);
+            nvgLineTo(getContext(), position.width, halfHeight + halfTriangleSize);
+            nvgLineTo(getContext(), position.width, halfHeight - halfTriangleSize);
+            nvgFill(getContext());
+        }
+        nvgClosePath(getContext());
+    }
+}

--- a/B78XH/CheckListTitle.h
+++ b/B78XH/CheckListTitle.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "Control.h"
+#include "Tools/Tools.h"
+
+/**
+ * \brief The title line displayed in the electronic checklist.
+ * This can show title for both checklists and menus, with the difference is the checklist one shows 2 "triangles" enclosing the title text
+ */
+class CheckListTitle : public Control {
+    public:
+        enum class TITLE_TYPE {
+            NORMAL_CHECKLIST,
+            NON_NORMAL_CHECKLIST,
+            MENU,
+        };
+    
+        CheckListTitle(const string& name, const TITLE_TYPE type, const string& titleText)
+            : Control(name),
+              titleText_(titleText), type_(type) {
+        }
+
+        auto render() -> void override;
+
+    private:
+        const string titleText_;
+        const TITLE_TYPE type_;
+};

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -10,6 +10,7 @@ void MFDCHKLControl::prepareControls() {
     add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP));
     const auto l2 = std::make_shared<CheckListLine>("TEST_LINE_2", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP);
     l2->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
+    l2->setIsCurrent(true);
     add(l2);
 }
 

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -22,6 +22,8 @@ void MFDCHKLControl::setupControls() {
                                                CheckListDimensions::TOTAL_LINE_HEIGHT);
     normalButton_->position.setPosition(0, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT, 150,
                                         position.height);
+    resetChecklistButton_->position.setPosition(300, 450, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT,
+                                                position.height);
 
     preflight_->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT, CheckListDimensions::TOTAL_WIDTH,
                                      position.height - CheckListDimensions::TOTAL_LINE_HEIGHT);

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -7,10 +7,10 @@ auto MFDCHKLControl::render() -> void {
 void MFDCHKLControl::prepareControls() {
 	MFDBaseControl::prepareControls();
 
-	add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::CLOSED_LOOP));
+	add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP));
 }
 
 void MFDCHKLControl::setupControls() {
 	MFDBaseControl::setupControls();
-	getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_WIDTH, CheckListDimensions::TOTAL_HEIGHT);
+	getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_WIDTH, CheckListDimensions::TOTAL_LINE_HEIGHT);
 }

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -7,6 +7,13 @@ auto MFDCHKLControl::render() -> void {
 void MFDCHKLControl::prepareControls() {
     MFDBaseControl::prepareControls();
 
+    normalMenuButton_ = std::make_shared<CheckListButton>("NORMAL_MENU", nullptr, "NORMAL MENU");
+    add(normalMenuButton_);
+    resetsButton_ = std::make_shared<CheckListButton>("RESETS", nullptr, "RESETS");
+    add(resetsButton_);
+    nonNormalMenuButton_ = std::make_shared<CheckListButton>("NON_NORMAL_MENU", nullptr, "NON-NORMAL MENU");
+    add(nonNormalMenuButton_);
+    
     add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP));
     const auto l2 = std::make_shared<CheckListLine>("TEST_LINE_2", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP);
     l2->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
@@ -16,9 +23,12 @@ void MFDCHKLControl::prepareControls() {
 
 void MFDCHKLControl::setupControls() {
     MFDBaseControl::setupControls();
-    getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_WIDTH,
-                                                  CheckListDimensions::TOTAL_LINE_HEIGHT);
-    getControl("TEST_LINE_2")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT,
-                                                  CheckListDimensions::TOTAL_WIDTH,
+    normalMenuButton_->position.setPosition(0, 0, 220, CheckListDimensions::TOTAL_LINE_HEIGHT);
+    resetsButton_->position.setPosition(220, 0, 390, CheckListDimensions::TOTAL_LINE_HEIGHT);
+    nonNormalMenuButton_->position.setPosition(390, 0, CheckListDimensions::TOTAL_WIDTH, CheckListDimensions::TOTAL_LINE_HEIGHT);
+    getControl("TEST_LINE")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT, CheckListDimensions::TOTAL_WIDTH,
                                                   CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
+    getControl("TEST_LINE_2")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 2,
+                                                  CheckListDimensions::TOTAL_WIDTH,
+                                                  CheckListDimensions::TOTAL_LINE_HEIGHT * 3);
 }

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -9,15 +9,15 @@ auto MFDCHKLControl::render() -> void {
 void MFDCHKLControl::prepareControls() {
     MFDBaseControl::prepareControls();
 
-    normalMenuButton_ = std::make_shared<CheckListButton>("NORMAL_MENU", nullptr, "NORMAL MENU");
     add(normalMenuButton_);
-    resetsButton_ = std::make_shared<CheckListButton>("RESETS", nullptr, "RESETS");
     add(resetsButton_);
-    nonNormalMenuButton_ = std::make_shared<CheckListButton>("NON_NORMAL_MENU", nullptr, "NON-NORMAL MENU");
     add(nonNormalMenuButton_);
+    add(normalButton_);
 
+    // TODO: Remove
     add(std::make_shared<CheckListTitle>("TEST_TITLE", CheckListTitle::TITLE_TYPE::NORMAL_CHECKLIST, "PREFLIGHT"));
-    const auto l1 = std::make_shared<CheckListLineSingle>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP, "Oxygen . . . . . . . . . . . . . . . . . . . . . . Tested,100%");
+    const auto l1 = std::make_shared<CheckListLineSingle>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
+                                                          "Oxygen . . . . . . . . . . . . . . . . . . . . . . Tested,100%");
     l1->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
     l1->setIsCurrent(true);
     add(l1);
@@ -32,6 +32,9 @@ void MFDCHKLControl::setupControls() {
     resetsButton_->position.setPosition(225, 0, 385, CheckListDimensions::TOTAL_LINE_HEIGHT);
     nonNormalMenuButton_->position.setPosition(395, 0, CheckListDimensions::TOTAL_WIDTH,
                                                CheckListDimensions::TOTAL_LINE_HEIGHT);
+    normalButton_->position.setPosition(0, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT, 150,
+                                        position.height);
+    // TODO: Remove
     getControl("TEST_TITLE")->position.setPosition(200, CheckListDimensions::TOTAL_LINE_HEIGHT, 500,
                                                    CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
     getControl("TEST_LINE")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 2,

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -1,16 +1,23 @@
 #include "MFDCHKLControl.h"
 
 auto MFDCHKLControl::render() -> void {
-	MFDBaseControl::render();
+    MFDBaseControl::render();
 }
 
 void MFDCHKLControl::prepareControls() {
-	MFDBaseControl::prepareControls();
+    MFDBaseControl::prepareControls();
 
-	add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP));
+    add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP));
+    const auto l2 = std::make_shared<CheckListLine>("TEST_LINE_2", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP);
+    l2->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
+    add(l2);
 }
 
 void MFDCHKLControl::setupControls() {
-	MFDBaseControl::setupControls();
-	getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_WIDTH, CheckListDimensions::TOTAL_LINE_HEIGHT);
+    MFDBaseControl::setupControls();
+    getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_WIDTH,
+                                                  CheckListDimensions::TOTAL_LINE_HEIGHT);
+    getControl("TEST_LINE_2")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT,
+                                                  CheckListDimensions::TOTAL_WIDTH,
+                                                  CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
 }

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -12,5 +12,5 @@ void MFDCHKLControl::prepareControls() {
 
 void MFDCHKLControl::setupControls() {
 	MFDBaseControl::setupControls();
-	getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_LINE_WIDTH, CheckListDimensions::TOTAL_LINE_HEIGHT);
+	getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_WIDTH, CheckListDimensions::TOTAL_HEIGHT);
 }

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -1,5 +1,7 @@
 #include "MFDCHKLControl.h"
 
+#include "CheckListLineSingle.h"
+
 auto MFDCHKLControl::render() -> void {
     MFDBaseControl::render();
 }
@@ -13,22 +15,29 @@ void MFDCHKLControl::prepareControls() {
     add(resetsButton_);
     nonNormalMenuButton_ = std::make_shared<CheckListButton>("NON_NORMAL_MENU", nullptr, "NON-NORMAL MENU");
     add(nonNormalMenuButton_);
-    
-    add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP));
+
+    add(std::make_shared<CheckListTitle>("TEST_TITLE", CheckListTitle::TITLE_TYPE::NORMAL_CHECKLIST, "PREFLIGHT"));
+    const auto l1 = std::make_shared<CheckListLineSingle>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP, "Oxygen . . . . . . . . . . . . . . . . . . . . . . Tested,100%");
+    l1->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
+    l1->setIsCurrent(true);
+    add(l1);
     const auto l2 = std::make_shared<CheckListLine>("TEST_LINE_2", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP);
     l2->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
-    l2->setIsCurrent(true);
     add(l2);
 }
 
 void MFDCHKLControl::setupControls() {
     MFDBaseControl::setupControls();
-    normalMenuButton_->position.setPosition(0, 0, 220, CheckListDimensions::TOTAL_LINE_HEIGHT);
-    resetsButton_->position.setPosition(220, 0, 390, CheckListDimensions::TOTAL_LINE_HEIGHT);
-    nonNormalMenuButton_->position.setPosition(390, 0, CheckListDimensions::TOTAL_WIDTH, CheckListDimensions::TOTAL_LINE_HEIGHT);
-    getControl("TEST_LINE")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT, CheckListDimensions::TOTAL_WIDTH,
-                                                  CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
-    getControl("TEST_LINE_2")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 2,
+    normalMenuButton_->position.setPosition(0, 0, 215, CheckListDimensions::TOTAL_LINE_HEIGHT);
+    resetsButton_->position.setPosition(225, 0, 385, CheckListDimensions::TOTAL_LINE_HEIGHT);
+    nonNormalMenuButton_->position.setPosition(395, 0, CheckListDimensions::TOTAL_WIDTH,
+                                               CheckListDimensions::TOTAL_LINE_HEIGHT);
+    getControl("TEST_TITLE")->position.setPosition(200, CheckListDimensions::TOTAL_LINE_HEIGHT, 500,
+                                                   CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
+    getControl("TEST_LINE")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 2,
                                                   CheckListDimensions::TOTAL_WIDTH,
                                                   CheckListDimensions::TOTAL_LINE_HEIGHT * 3);
+    getControl("TEST_LINE_2")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 3,
+                                                    CheckListDimensions::TOTAL_WIDTH,
+                                                    CheckListDimensions::TOTAL_LINE_HEIGHT * 4);
 }

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -1,0 +1,16 @@
+#include "MFDCHKLControl.h"
+
+auto MFDCHKLControl::render() -> void {
+	MFDBaseControl::render();
+}
+
+void MFDCHKLControl::prepareControls() {
+	MFDBaseControl::prepareControls();
+
+	add(std::make_shared<CheckListLine>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::CLOSED_LOOP));
+}
+
+void MFDCHKLControl::setupControls() {
+	MFDBaseControl::setupControls();
+	getControl("TEST_LINE")->position.setPosition(0, 0, CheckListDimensions::TOTAL_LINE_WIDTH, CheckListDimensions::TOTAL_LINE_HEIGHT);
+}

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -1,7 +1,5 @@
 #include "MFDCHKLControl.h"
 
-#include "CheckListLineSingle.h"
-
 auto MFDCHKLControl::render() -> void {
     MFDBaseControl::render();
 }
@@ -13,17 +11,7 @@ void MFDCHKLControl::prepareControls() {
     add(resetsButton_);
     add(nonNormalMenuButton_);
     add(normalButton_);
-
-    // TODO: Remove
-    add(std::make_shared<CheckListTitle>("TEST_TITLE", CheckListTitle::TITLE_TYPE::NORMAL_CHECKLIST, "PREFLIGHT"));
-    const auto l1 = std::make_shared<CheckListLineSingle>("TEST_LINE", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
-                                                          "Oxygen . . . . . . . . . . . . . . . . . . . . . . Tested,100%");
-    l1->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
-    l1->setIsCurrent(true);
-    add(l1);
-    const auto l2 = std::make_shared<CheckListLine>("TEST_LINE_2", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP);
-    l2->setCurrentState(CheckListItem::CHECKLIST_ITEM_STATE::COMPLETED);
-    add(l2);
+    add(preflight_);
 }
 
 void MFDCHKLControl::setupControls() {
@@ -34,13 +22,7 @@ void MFDCHKLControl::setupControls() {
                                                CheckListDimensions::TOTAL_LINE_HEIGHT);
     normalButton_->position.setPosition(0, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT, 150,
                                         position.height);
-    // TODO: Remove
-    getControl("TEST_TITLE")->position.setPosition(200, CheckListDimensions::TOTAL_LINE_HEIGHT, 500,
-                                                   CheckListDimensions::TOTAL_LINE_HEIGHT * 2);
-    getControl("TEST_LINE")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 2,
-                                                  CheckListDimensions::TOTAL_WIDTH,
-                                                  CheckListDimensions::TOTAL_LINE_HEIGHT * 3);
-    getControl("TEST_LINE_2")->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT * 3,
-                                                    CheckListDimensions::TOTAL_WIDTH,
-                                                    CheckListDimensions::TOTAL_LINE_HEIGHT * 4);
+
+    preflight_->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT, CheckListDimensions::TOTAL_WIDTH,
+                                     position.height - CheckListDimensions::TOTAL_LINE_HEIGHT);
 }

--- a/B78XH/MFDCHKLControl.cpp
+++ b/B78XH/MFDCHKLControl.cpp
@@ -11,6 +11,7 @@ void MFDCHKLControl::prepareControls() {
     add(resetsButton_);
     add(nonNormalMenuButton_);
     add(normalButton_);
+    add(resetChecklistButton_);
     add(preflight_);
 }
 
@@ -22,7 +23,7 @@ void MFDCHKLControl::setupControls() {
                                                CheckListDimensions::TOTAL_LINE_HEIGHT);
     normalButton_->position.setPosition(0, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT, 150,
                                         position.height);
-    resetChecklistButton_->position.setPosition(300, 450, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT,
+    resetChecklistButton_->position.setPosition(300, position.height - CheckListDimensions::TOTAL_LINE_HEIGHT, 450,
                                                 position.height);
 
     preflight_->position.setPosition(0, CheckListDimensions::TOTAL_LINE_HEIGHT, CheckListDimensions::TOTAL_WIDTH,

--- a/B78XH/MFDCHKLControl.h
+++ b/B78XH/MFDCHKLControl.h
@@ -17,7 +17,9 @@ class MFDCHKLControl : public MFDBaseControl {
         auto setupControls() -> void override;
 
     private:
-        std::shared_ptr<CheckListButton> normalMenuButton_;
-        std::shared_ptr<CheckListButton> resetsButton_;
-        std::shared_ptr<CheckListButton> nonNormalMenuButton_;
+        std::shared_ptr<CheckListButton> normalMenuButton_ = std::make_shared<CheckListButton>("NORMAL_MENU", nullptr, "NORMAL MENU");
+        std::shared_ptr<CheckListButton> resetsButton_ = std::make_shared<CheckListButton>("RESETS", nullptr, "RESETS");
+        std::shared_ptr<CheckListButton> nonNormalMenuButton_ = std::make_shared<CheckListButton>("NON_NORMAL_MENU", nullptr, "NON-NORMAL MENU");
+
+        std::shared_ptr<CheckListButton> normalButton_ = std::make_shared<CheckListButton>("NORMAL", nullptr, "NORMAL");
 };

--- a/B78XH/MFDCHKLControl.h
+++ b/B78XH/MFDCHKLControl.h
@@ -1,16 +1,22 @@
 #pragma once
 #include "MFDBaseControl.h"
 #include "CheckListLine.h"
+#include "CheckListButton.h"
 #include "CheckListDimensions.h"
 
 class MFDCHKLControl : public MFDBaseControl {
-public:
-	explicit MFDCHKLControl(const string& name)
-		: MFDBaseControl(name) {
-		ident_ = CONTROL_IDENT::CHKL;
-	}
+    public:
+        explicit MFDCHKLControl(const string& name)
+            : MFDBaseControl(name) {
+            ident_ = CONTROL_IDENT::CHKL;
+        }
 
-	auto render() -> void override;
-	auto prepareControls() -> void override;
-	auto setupControls() -> void override;
+        auto render() -> void override;
+        auto prepareControls() -> void override;
+        auto setupControls() -> void override;
+
+    private:
+        std::shared_ptr<CheckListButton> normalMenuButton_;
+        std::shared_ptr<CheckListButton> resetsButton_;
+        std::shared_ptr<CheckListButton> nonNormalMenuButton_;
 };

--- a/B78XH/MFDCHKLControl.h
+++ b/B78XH/MFDCHKLControl.h
@@ -22,6 +22,7 @@ class MFDCHKLControl : public MFDBaseControl {
         std::shared_ptr<CheckListButton> resetsButton_ = std::make_shared<CheckListButton>("RESETS", nullptr, "RESETS");
         std::shared_ptr<CheckListButton> nonNormalMenuButton_ = std::make_shared<CheckListButton>("NON_NORMAL_MENU", nullptr, "NON-NORMAL MENU");
         std::shared_ptr<CheckListButton> normalButton_ = std::make_shared<CheckListButton>("NORMAL", nullptr, "NORMAL");
+        std::shared_ptr<CheckListButton> resetChecklistButton_ = std::make_shared<CheckListButton>("CHKL_RESET", nullptr, "CHKL\nRESET");
 
         // TODO: Temp, remove, use a "current pointer"
         std::shared_ptr<PreFlightCheckList> preflight_ = std::make_shared<PreFlightCheckList>("PREFLIGHT");

--- a/B78XH/MFDCHKLControl.h
+++ b/B78XH/MFDCHKLControl.h
@@ -4,6 +4,7 @@
 #include "CheckListTitle.h"
 #include "CheckListButton.h"
 #include "CheckListDimensions.h"
+#include "PreFlightCheckList.h"
 
 class MFDCHKLControl : public MFDBaseControl {
     public:
@@ -20,6 +21,8 @@ class MFDCHKLControl : public MFDBaseControl {
         std::shared_ptr<CheckListButton> normalMenuButton_ = std::make_shared<CheckListButton>("NORMAL_MENU", nullptr, "NORMAL MENU");
         std::shared_ptr<CheckListButton> resetsButton_ = std::make_shared<CheckListButton>("RESETS", nullptr, "RESETS");
         std::shared_ptr<CheckListButton> nonNormalMenuButton_ = std::make_shared<CheckListButton>("NON_NORMAL_MENU", nullptr, "NON-NORMAL MENU");
-
         std::shared_ptr<CheckListButton> normalButton_ = std::make_shared<CheckListButton>("NORMAL", nullptr, "NORMAL");
+
+        // TODO: Temp, remove, use a "current pointer"
+        std::shared_ptr<PreFlightCheckList> preflight_ = std::make_shared<PreFlightCheckList>("PREFLIGHT");
 };

--- a/B78XH/MFDCHKLControl.h
+++ b/B78XH/MFDCHKLControl.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "MFDBaseControl.h"
+#include "CheckListLine.h"
+#include "CheckListDimensions.h"
+
+class MFDCHKLControl : public MFDBaseControl {
+public:
+	explicit MFDCHKLControl(const string& name)
+		: MFDBaseControl(name) {
+		ident_ = CONTROL_IDENT::CHKL;
+	}
+
+	auto render() -> void override;
+	auto prepareControls() -> void override;
+	auto setupControls() -> void override;
+};

--- a/B78XH/MFDCHKLControl.h
+++ b/B78XH/MFDCHKLControl.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "MFDBaseControl.h"
 #include "CheckListLine.h"
+#include "CheckListTitle.h"
 #include "CheckListButton.h"
 #include "CheckListDimensions.h"
 

--- a/B78XH/MFDPanelResolver.h
+++ b/B78XH/MFDPanelResolver.h
@@ -6,6 +6,7 @@
 #include "MFDEmptyControl.h"
 #include "MFDNDControl.h"
 #include "MFDSYSControl.h"
+#include "MFDCHKLControl.h"
 
 class MFDPanelResolver {
 	public:
@@ -70,7 +71,7 @@ class MFDPanelResolver {
 		std::array<std::shared_ptr<MFDBaseControl>, 6> mfdOnePanels{
 			std::make_shared<MFDSYSControl>("MFDEmptyControl"),
 			std::make_shared<MFDINFOControl>("MFDEmptyControl"),
-			std::make_shared<MFDCHKLControl>("MFDEmptyControl"),
+			std::make_shared<MFDCHKLControl>("MFDCHKLControl"),
 			std::make_shared<MFDCOMMControl>("MFDEmptyControl"),
 			std::make_shared<MFDNDControl>("MFDEmptyControl"),
 			std::make_shared<MFDEmptyControl>("MFDEmptyControl")
@@ -79,7 +80,7 @@ class MFDPanelResolver {
 		std::array<std::shared_ptr<MFDBaseControl>, 6> mfdTwoPanels{
 			std::make_shared<MFDSYSControl>("MFDEmptyControl"),
 			std::make_shared<MFDINFOControl>("MFDEmptyControl"),
-			std::make_shared<MFDCHKLControl>("MFDEmptyControl"),
+			std::make_shared<MFDCHKLControl>("MFDCHKLControl"),
 			std::make_shared<MFDCOMMControl>("MFDEmptyControl"),
 			std::make_shared<MFDNDControl>("MFDEmptyControl"),
 			std::make_shared<MFDEmptyControl>("MFDEmptyControl")
@@ -88,7 +89,7 @@ class MFDPanelResolver {
 		std::array<std::shared_ptr<MFDBaseControl>, 6> mfdThreePanels{
 			std::make_shared<MFDSYSControl>("MFDEmptyControl"),
 			std::make_shared<MFDINFOControl>("MFDEmptyControl"),
-			std::make_shared<MFDCHKLControl>("MFDEmptyControl"),
+			std::make_shared<MFDCHKLControl>("MFDCHKLControl"),
 			std::make_shared<MFDCOMMControl>("MFDEmptyControl"),
 			std::make_shared<MFDNDControl>("MFDEmptyControl"),
 			std::make_shared<MFDEmptyControl>("MFDEmptyControl")

--- a/B78XH/MFDSYSControl.cpp
+++ b/B78XH/MFDSYSControl.cpp
@@ -24,17 +24,6 @@ auto MFDINFOControl::render() -> void {
 	nvgClosePath(getContext());
 }
 
-auto MFDCHKLControl::render() -> void {
-	MFDBaseControl::render();
-	nvgBeginPath(getContext());
-	{
-		nvgFillColor(getContext(), nvgRGB(0, 0, 255));
-		nvgRect(getContext(), 0, 0, 200, 200);
-		nvgFill(getContext());
-	}
-	nvgClosePath(getContext());
-}
-
 auto MFDCOMMControl::render() -> void {
 	MFDBaseControl::render();
 	nvgBeginPath(getContext());

--- a/B78XH/MFDSYSControl.h
+++ b/B78XH/MFDSYSControl.h
@@ -21,16 +21,6 @@ class MFDINFOControl : public MFDBaseControl {
 		auto render() -> void override;
 };
 
-class MFDCHKLControl : public MFDBaseControl {
-	public:
-		explicit MFDCHKLControl(const string& name)
-			: MFDBaseControl(name) {
-			ident_ = CONTROL_IDENT::TEST3;
-		}
-
-		auto render() -> void override;
-};
-
 class MFDCOMMControl : public MFDBaseControl {
 	public:
 		explicit MFDCOMMControl(const string& name)

--- a/B78XH/PreFlightCheckList.cpp
+++ b/B78XH/PreFlightCheckList.cpp
@@ -1,0 +1,1 @@
+#include "PreFlightCheckList.h"

--- a/B78XH/PreFlightCheckList.h
+++ b/B78XH/PreFlightCheckList.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "CheckList.h"
+
+class PreFlightCheckList : public CheckList {
+    public:
+        explicit PreFlightCheckList(const string& name)
+            : CheckList(name, CheckListTitle::TITLE_TYPE::NORMAL_CHECKLIST, "PREFLIGHT") {
+            lines_.push_back(std::make_shared<CheckListLineSingle>(
+                "OXYGEN", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
+                "Oxygen . . . . . . . . . . . . . . . . . . . . . . Tested,100%"));
+        }
+};

--- a/B78XH/PreFlightCheckList.h
+++ b/B78XH/PreFlightCheckList.h
@@ -8,5 +8,12 @@ class PreFlightCheckList : public CheckList {
             lines_.push_back(std::make_shared<CheckListLineSingle>(
                 "OXYGEN", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
                 "Oxygen . . . . . . . . . . . . . . . . . . . . . . Tested,100%"));
+            lines_.push_back(std::make_shared<CheckListLineSingle>(
+                "FLIGHT_INST", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
+                "Flight Instruments . . . Heading___,Altimeter___"));
+            lines_.push_back(std::make_shared<CheckListLineSingle>(
+                "PAX_SIGN", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
+                "Passenger Signs . . . . . . . . . . . . . . Set"));
+            resetChecklist();
         }
 };

--- a/B78XH/PreFlightCheckList.h
+++ b/B78XH/PreFlightCheckList.h
@@ -13,7 +13,7 @@ class PreFlightCheckList : public CheckList {
                 "Flight Instruments . . . Heading___,Altimeter___"));
             lines_.push_back(std::make_shared<CheckListLineSingle>(
                 "PAX_SIGN", CheckListLine::CHECKLIST_LINE_TYPE::OPEN_LOOP,
-                "Passenger Signs . . . . . . . . . . . . . . Set"));
+                "Passenger Signs . . . . . . . . . . . . . . . . . . . . . Set"));
             resetChecklist();
         }
 };


### PR DESCRIPTION
This PR aims to add normal checklist functionality to allow in-cockpit interaction of the checklist on the MFD. The entire suite of checklists is huge so I plan to just do the normal checklists for this PR and we can tackle the non-normal ones separately. This PR should set up the checklist UI components (like checkboxes, etc.) to allow us to quickly put together other checklists. Within the scope, interactions will be as close to real-life ones as possible with available systems.

**Scope**
----
Interaction with the normal checklists (PREFLIGHT, BEFORE START, AFTER START, BEFORE TAKEOFF, AFTER TAKEOFF, APPROACH, LANDING, SHUTDOWN, SECURE)
No plan to integrate with the "MSFS checklist" window, for now, this will be only available in the cockpit MFD.